### PR TITLE
開発環境の改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - 「平成30年度野田地区新入生歓迎ガイダンス」などで実運用されていた。
 
 ## 開発環境セットアップ方法
-Git、PHP、Composer、Node.js、Yarn、Docker がセットアップ済みである必要があります。
+Git、PHP(7.3以上)、Composer、Node.js、Yarn、Docker がセットアップ済みである必要があります。
 
 ```bash
 $ git clone git@github.com:portal-dots/PortalDots.git
@@ -39,28 +39,28 @@ $ composer install
 $ yarn install
 
 # 開発環境を起動する
-$ composer docker
+$ yarn docker
 
 # マイグレーション
 #
 # ⚠️ α版注）データベース構造に関して、現在破壊的な変更を継続して行なっています。
 # 　もしデータベースエラーが発生する場合、開発環境を再ビルドしてから
-# 　代わりに `composer migrate:refresh` コマンドを実行してください。
-$ composer migrate
+# 　代わりに `yarn migrate:refresh` コマンドを実行してください。
+$ yarn migrate
 
 # フロントエンド用アセットのコンパイル
 $ yarn watch
 # Ctrl-C で停止
 
 # 開発環境を停止する
-$ composer docker-stop
+$ yarn docker-stop
 ```
 
-- `composer docker` コマンドにより、開発環境が起動します。
+- `yarn docker` コマンドにより、開発環境が起動します。
 
 ## 開発環境の各種 URL
 - 開発環境 : http://localhost:3000
-    - 初回アクセス時、データベースエラーが表示されることがありますが、数回再読み込みすることでエラーは解消するようです。もし解消しない場合、 `composer docker-stop` コマンドを実行してから `composer docker` コマンドを実行し、開発環境を再起動してください。
+    - 初回アクセス時、データベースエラーが表示されることがありますが、数回再読み込みすることでエラーは解消するようです。もし解消しない場合、 `yarn docker-stop` コマンドを実行してから `yarn docker` コマンドを実行し、開発環境を再起動してください。
 - 開発環境から送信されるメールの確認(MailHog) : http://localhost:8025
 - phpMyAdmin : http://localhost:8080
     - 開発環境の DB に作成されるデータベース名は `db_portal_dev`

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,6 @@
 {
+    "name": "portal-dots/portaldots",
+    "description": "",
     "type": "project",
     "license": "MIT",
 	"require": {
@@ -54,27 +56,6 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
 	"scripts": {
-		"docker": [
-			"cd docker_dev && docker-compose up -d"
-		],
-		"docker-build": [
-			"cd docker_dev && docker-compose up -d --build"
-		],
-		"docker-stop": [
-			"cd docker_dev && docker-compose down"
-		],
-        "migrate": [
-            "cd docker_dev && docker-compose run web php artisan migrate"
-        ],
-        "migrate:status": [
-            "cd docker_dev && docker-compose run web php artisan migrate:status"
-        ],
-        "migrate:rollback": [
-            "cd docker_dev && docker-compose run web php artisan migrate:rollback"
-        ],
-        "migrate:refresh": [
-            "cd docker_dev && docker-compose run web php artisan migrate:refresh"
-        ],
         "phpcs": [
             "phpcs --standard=phpcs.xml ./"
         ],

--- a/docker_dev/docker-compose.yml
+++ b/docker_dev/docker-compose.yml
@@ -1,13 +1,6 @@
 version: '3'
 
 services:
-  php-cli:
-    container_name: portal_php_cli
-    build: ./web
-    volumes:
-      - ../:/var/www/html
-      - ./data/web/logs:/docker_web_logs
-
   web:
     container_name: portal_web
     build: ./web

--- a/docker_dev/web/Dockerfile
+++ b/docker_dev/web/Dockerfile
@@ -1,11 +1,13 @@
-FROM php:7.3-apache
-ADD ./php/php.ini /usr/local/etc/php/
-ADD ./apache/*.conf /etc/apache2/sites-enabled/
+FROM php:7.3.16-apache-buster
+COPY ./php/php.ini /usr/local/etc/php/
+COPY ./apache/*.conf /etc/apache2/sites-enabled/
 
 RUN apt-get update \
-    && apt-get install -y zlib1g-dev libpq-dev libzip-dev default-mysql-client unzip wget \
+    && apt-get install -y --no-install-recommends zlib1g-dev libpq-dev libzip-dev libpng-dev default-mysql-client unzip wget \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
     && pecl install xdebug \
-    && docker-php-ext-install zip pdo_mysql mysqli \
+    && docker-php-ext-install zip pdo_mysql mysqli gd \
     && docker-php-ext-enable mysqli xdebug
 
 RUN a2enmod rewrite

--- a/package.json
+++ b/package.json
@@ -12,6 +12,13 @@
     },
     "homepage": "https://github.com/portal-dots/PortalDots#readme",
     "scripts": {
+        "docker": "cd docker_dev && docker-compose up -d --build",
+        "docker-bash": "cd docker_dev/ && docker-compose exec web bash",
+        "docker-stop": "cd docker_dev && docker-compose down",
+        "migrate": "cd docker_dev && docker-compose run web php artisan migrate",
+        "migrate:status": "cd docker_dev && docker-compose run web php artisan migrate:status",
+        "migrate:rollback": "cd docker_dev && docker-compose run web php artisan migrate:rollback",
+        "migrate:refresh": "cd docker_dev && docker-compose run web php artisan migrate:refresh",
         "dev": "npm run development",
         "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "watch": "npm run development -- --watch",
@@ -19,7 +26,6 @@
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prod": "npm run production",
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "docker-bash": "cd docker_dev/ && docker-compose exec web bash",
         "eslint-check": "eslint --ext js,vue ./resources",
         "stylelint-check": "stylelint ./resources/**/*.{vue,scss}"
     },


### PR DESCRIPTION
## 実装内容
@hosakou 

- Docker の PHP が 7.2 になっていたので、7.3 にしました
- Cassisboard の Docker 起動コマンドが `yarn docker` なのに、PortalDots は `composer docker` になっていたややこしかった＋composer scripts は使い勝手が悪い（オプション引数を渡せない）ので、`yarn docker` にしました
    - 今まで `composer なんとか` で実行していたコマンドは全部 `yarn なんとか` にしました
- `yarn docker` で実行されるコマンドに `--build` というオプション引数を追加しました

## 懸念点

## レビュワーに見て欲しい点
レビュワーがapproveしないとmasterにマージできないようにしてみました。
ちょっと面倒かもだけど、お互いにチェックしたほうが今後の開発しやすいかなと思い

## 参考URL
