### PR TITLE
【申請】スタッフが回答を編集できるようにする #37

### DIFF
--- a/app/Eloquents/Circle.php
+++ b/app/Eloquents/Circle.php
@@ -40,15 +40,6 @@ class Circle extends Model
         'notes',
     ];
 
-    protected static function boot()
-    {
-        parent::boot();
-
-        static::addGlobalScope('approved', function (Builder $builder) {
-            $builder->whereNotNull('submitted_at')->where('status', 'approved');
-        });
-    }
-
     public function users()
     {
         return $this->belongsToMany(User::class)->using(CircleUser::class)->withPivot('is_leader');

--- a/app/Eloquents/CustomForm.php
+++ b/app/Eloquents/CustomForm.php
@@ -109,7 +109,7 @@ class CustomForm extends Model
         if (empty($forms[$type]) || static::$noCacheForm) {
             $custom_form = self::where('type', $type)->first();
             if (!empty($custom_form)) {
-                $forms[$type] = $custom_form->form()->withoutGlobalScope('withoutCustomForms')->first();
+                $forms[$type] = $custom_form->form()->first();
             }
         }
 

--- a/app/Eloquents/Form.php
+++ b/app/Eloquents/Form.php
@@ -44,13 +44,12 @@ class Form extends Model
         'is_public' => 'bool',
     ];
 
-    protected static function boot()
+    /**
+     * カスタムフォームは含めない
+     */
+    public function scopeWithoutCustomForms($query)
     {
-        parent::boot();
-
-        static::addGlobalScope('withoutCustomForms', function (Builder $builder) {
-            $builder->doesntHave('customForm');
-        });
+        return $query->doesntHave('customForm');
     }
 
     /**

--- a/app/Http/Controllers/Circles/Selector/ShowAction.php
+++ b/app/Http/Controllers/Circles/Selector/ShowAction.php
@@ -19,7 +19,7 @@ class ShowAction extends Controller
         $redirect = $request->redirect;
         if (isset($redirect) && $this->router->has($redirect)) {
             $user = Auth::user();
-            $circles = $user->circles()->get();
+            $circles = $user->circles()->approved()->get();
 
             if (count($circles) <= 1) {
                 return redirect()

--- a/app/Http/Controllers/Circles/StatusAction.php
+++ b/app/Http/Controllers/Circles/StatusAction.php
@@ -11,7 +11,7 @@ class StatusAction extends Controller
 {
     public function __invoke(Circle $circle)
     {
-        $circle = Auth::user()->circles()->withoutGlobalScope('approved')->rejected()->findOrFail($circle->id);
+        $circle = Auth::user()->circles()->rejected()->findOrFail($circle->id);
 
         // status_reason が空の場合、このページはアクセス不可(というより 404 )とする
         if (empty($circle->status_reason)) {

--- a/app/Http/Controllers/Circles/Users/DestroyAction.php
+++ b/app/Http/Controllers/Circles/Users/DestroyAction.php
@@ -22,7 +22,7 @@ class DestroyAction extends Controller
     {
         $this->authorize('circle.update', $circle);
 
-        if ($user->circles()->withoutGlobalScope('approved')->findOrFail($circle->id)->pivot->is_leader) {
+        if ($user->circles()->findOrFail($circle->id)->pivot->is_leader) {
             return redirect()
                 ->route('circles.users.index', ['circle' => $circle])
                 ->with('topAlert.type', 'danger')

--- a/app/Http/Controllers/Contacts/CreateAction.php
+++ b/app/Http/Controllers/Contacts/CreateAction.php
@@ -12,6 +12,6 @@ class CreateAction extends Controller
     public function __invoke()
     {
         return view('v2.contacts.form')
-            ->with('circles', Auth::user()->circles()->withoutGlobalScope('approved')->get());
+            ->with('circles', Auth::user()->circles()->get());
     }
 }

--- a/app/Http/Controllers/Forms/AllAction.php
+++ b/app/Http/Controllers/Forms/AllAction.php
@@ -13,10 +13,10 @@ class AllAction extends Controller
 {
     public function __invoke(Request $request)
     {
-        $forms = Form::public()->closeOrder()->paginate(10);
+        $forms = Form::public()->withoutCustomForms()->closeOrder()->paginate(10);
         $circle = Circle::approved()->find($request->circle);
         if (empty($circle) || Gate::denies('circle.belongsTo', $circle)) {
-            $circles = Auth::user()->circles()->get();
+            $circles = Auth::user()->circles()->approved()->get();
             if (count($circles) < 1) {
                 return view('v2.forms.list');
             } elseif (count($circles) === 1) {

--- a/app/Http/Controllers/Forms/AllAction.php
+++ b/app/Http/Controllers/Forms/AllAction.php
@@ -14,7 +14,7 @@ class AllAction extends Controller
     public function __invoke(Request $request)
     {
         $forms = Form::public()->closeOrder()->paginate(10);
-        $circle = Circle::find($request->circle);
+        $circle = Circle::approved()->find($request->circle);
         if (empty($circle) || Gate::denies('circle.belongsTo', $circle)) {
             $circles = Auth::user()->circles()->get();
             if (count($circles) < 1) {

--- a/app/Http/Controllers/Forms/Answers/CreateAction.php
+++ b/app/Http/Controllers/Forms/Answers/CreateAction.php
@@ -21,9 +21,8 @@ class CreateAction extends Controller
 
     public function __invoke(Form $form, Request $request)
     {
-        if (! $form->is_public) {
+        if (! $form->is_public || isset($form->customForm)) {
             abort(404);
-            return;
         }
 
         $circle = null;

--- a/app/Http/Controllers/Forms/Answers/CreateAction.php
+++ b/app/Http/Controllers/Forms/Answers/CreateAction.php
@@ -27,7 +27,7 @@ class CreateAction extends Controller
 
         $circle = null;
         if (empty($request->circle)) {
-            $circles = Auth::user()->circles;
+            $circles = Auth::user()->circles()->approved()->get();
             if (count($circles) < 1) {
                 // TODO: もうちょっとまともなエラー表示にする
                 return redirect()
@@ -43,7 +43,7 @@ class CreateAction extends Controller
                     ->with('circles', $circles);
             }
         } else {
-            $circle = Circle::findOrFail($request->circle);
+            $circle = Circle::approved()->findOrFail($request->circle);
             if (Gate::denies('circle.belongsTo', $circle)) {
                 // TODO: もうちょっとまともなエラー表示にする
                 abort(403);

--- a/app/Http/Controllers/Forms/Answers/EditAction.php
+++ b/app/Http/Controllers/Forms/Answers/EditAction.php
@@ -28,7 +28,7 @@ class EditAction extends Controller
 
     public function __invoke(Form $form, Answer $answer)
     {
-        if (! $form->is_public || $form->id !== $answer->form_id) {
+        if (! $form->is_public || $form->id !== $answer->form_id || isset($form->customForm)) {
             abort(404);
             return;
         }

--- a/app/Http/Controllers/Forms/Answers/EditAction.php
+++ b/app/Http/Controllers/Forms/Answers/EditAction.php
@@ -33,7 +33,7 @@ class EditAction extends Controller
             return;
         }
 
-        $circle = $answer->circle;
+        $circle = $answer->circle()->approved()->firstOrFail();
         return view('v2.forms.answers.form')
             ->with('circle', $circle)
             ->with('form', $form)

--- a/app/Http/Controllers/Forms/Answers/StoreAction.php
+++ b/app/Http/Controllers/Forms/Answers/StoreAction.php
@@ -20,6 +20,10 @@ class StoreAction extends Controller
 
     public function __invoke(Form $form, StoreAnswerRequest $request)
     {
+        if (isset($form->customForm)) {
+            abort(404);
+        }
+
         $circle = Circle::findOrFail($request->circle_id);
         $answer = $this->answersService->createAnswer($form, $circle, $request);
         if ($answer) {

--- a/app/Http/Controllers/Forms/Answers/StoreAction.php
+++ b/app/Http/Controllers/Forms/Answers/StoreAction.php
@@ -24,7 +24,7 @@ class StoreAction extends Controller
             abort(404);
         }
 
-        $circle = Circle::findOrFail($request->circle_id);
+        $circle = Circle::approved()->findOrFail($request->circle_id);
         $answer = $this->answersService->createAnswer($form, $circle, $request);
         if ($answer) {
             $this->answersService->sendAll($answer, Auth::user());

--- a/app/Http/Controllers/Forms/Answers/UpdateAction.php
+++ b/app/Http/Controllers/Forms/Answers/UpdateAction.php
@@ -21,6 +21,10 @@ class UpdateAction extends Controller
 
     public function __invoke(Form $form, Answer $answer, UpdateAnswerRequest $request)
     {
+        if (isset($form->customForm)) {
+            abort(404);
+        }
+
         $this->answersService->updateAnswer($form, $answer, $request);
         $this->answersService->sendAll($answer, Auth::user());
         return back()

--- a/app/Http/Controllers/Forms/Answers/Uploads/ShowAction.php
+++ b/app/Http/Controllers/Forms/Answers/Uploads/ShowAction.php
@@ -15,7 +15,7 @@ class ShowAction extends Controller
     public function __invoke(Request $request, int $form_id, Answer $answer, int $question_id)
     {
         // Form と Question については、DB から情報を取ってくる必要がないので、int で受け取る
-        $circle = $answer->circle()->withoutGlobalScope('approved')->first();
+        $circle = $answer->circle()->first();
         if (Gate::denies('circle.belongsTo', $circle)) {
             abort(404);
         }

--- a/app/Http/Controllers/Forms/ClosedAction.php
+++ b/app/Http/Controllers/Forms/ClosedAction.php
@@ -13,10 +13,10 @@ class ClosedAction extends Controller
 {
     public function __invoke(Request $request)
     {
-        $forms = Form::public()->closed()->closeOrder()->paginate(10);
+        $forms = Form::public()->withoutCustomForms()->closed()->closeOrder()->paginate(10);
         $circle = Circle::approved()->find($request->circle);
         if (empty($circle) || Gate::denies('circle.belongsTo', $circle)) {
-            $circles = Auth::user()->circles()->get();
+            $circles = Auth::user()->circles()->approved()->get();
             if (count($circles) < 1) {
                 return view('v2.forms.list');
             } elseif (count($circles) === 1) {

--- a/app/Http/Controllers/Forms/ClosedAction.php
+++ b/app/Http/Controllers/Forms/ClosedAction.php
@@ -14,7 +14,7 @@ class ClosedAction extends Controller
     public function __invoke(Request $request)
     {
         $forms = Form::public()->closed()->closeOrder()->paginate(10);
-        $circle = Circle::find($request->circle);
+        $circle = Circle::approved()->find($request->circle);
         if (empty($circle) || Gate::denies('circle.belongsTo', $circle)) {
             $circles = Auth::user()->circles()->get();
             if (count($circles) < 1) {

--- a/app/Http/Controllers/Forms/IndexAction.php
+++ b/app/Http/Controllers/Forms/IndexAction.php
@@ -13,10 +13,10 @@ class IndexAction extends Controller
 {
     public function __invoke(Request $request)
     {
-        $forms = Form::public()->open()->closeOrder()->paginate(10);
+        $forms = Form::public()->withoutCustomForms()->open()->closeOrder()->paginate(10);
         $circle = Circle::approved()->find($request->circle);
         if (empty($circle) || Gate::denies('circle.belongsTo', $circle)) {
-            $circles = Auth::user()->circles()->get();
+            $circles = Auth::user()->circles()->approved()->get();
             if (count($circles) < 1) {
                 return view('v2.forms.list');
             } elseif (count($circles) === 1) {

--- a/app/Http/Controllers/Forms/IndexAction.php
+++ b/app/Http/Controllers/Forms/IndexAction.php
@@ -14,7 +14,7 @@ class IndexAction extends Controller
     public function __invoke(Request $request)
     {
         $forms = Form::public()->open()->closeOrder()->paginate(10);
-        $circle = Circle::find($request->circle);
+        $circle = Circle::approved()->find($request->circle);
         if (empty($circle) || Gate::denies('circle.belongsTo', $circle)) {
             $circles = Auth::user()->circles()->get();
             if (count($circles) < 1) {

--- a/app/Http/Controllers/HomeAction.php
+++ b/app/Http/Controllers/HomeAction.php
@@ -22,7 +22,7 @@ class HomeAction extends Controller
         return view('v2.home')
             ->with('circle_custom_form', CustomForm::getFormByType('circle'))
             ->with('my_circles', Auth::check()
-                                    ? Auth::user()->circles()->withoutGlobalScope('approved')->get()
+                                    ? Auth::user()->circles()->get()
                                     : collect([]))
             ->with('pages', Page::take(self::TAKE_COUNT)->get())
             ->with('remaining_pages_count', max(Page::count() - self::TAKE_COUNT, 0))

--- a/app/Http/Controllers/Staff/Circles/CreateAction.php
+++ b/app/Http/Controllers/Staff/Circles/CreateAction.php
@@ -4,11 +4,13 @@ namespace App\Http\Controllers\Staff\Circles;
 
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use App\Eloquents\CustomForm;
 
 class CreateAction extends Controller
 {
     public function __invoke()
     {
-        return view('staff.circles.form');
+        return view('staff.circles.form')
+            ->with('custom_form', CustomForm::getFormByType('circle'));
     }
 }

--- a/app/Http/Controllers/Staff/Circles/EditAction.php
+++ b/app/Http/Controllers/Staff/Circles/EditAction.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Staff\Circles;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Eloquents\Circle;
+use App\Eloquents\CustomForm;
 
 class EditAction extends Controller
 {
@@ -21,6 +22,7 @@ class EditAction extends Controller
         }
 
         return view('staff.circles.form')
+            ->with('custom_form', CustomForm::getFormByType('circle'))
             ->with('circle', $circle)
             ->with('leader', $circle->users->filter(function ($user) {
                 return $user->pivot->is_leader;

--- a/app/Http/Controllers/Staff/Circles/EditAction.php
+++ b/app/Http/Controllers/Staff/Circles/EditAction.php
@@ -11,6 +11,11 @@ class EditAction extends Controller
 {
     public function __invoke(Circle $circle)
     {
+        if (!$circle->hasSubmitted()) {
+            // 参加登録が未提出の企画の情報は閲覧・編集できない
+            abort(404);
+        }
+
         $circle->load('users');
 
         $member_ids = '';

--- a/app/Http/Controllers/Staff/Circles/UpdateAction.php
+++ b/app/Http/Controllers/Staff/Circles/UpdateAction.php
@@ -18,6 +18,11 @@ class UpdateAction extends Controller
 
     public function __invoke(Circle $circle, CircleRequest $request)
     {
+        if (!$circle->hasSubmitted()) {
+            // 参加登録が未提出の企画の情報は閲覧・編集できない
+            abort(404);
+        }
+
         $member_ids = str_replace(["\r\n", "\r", "\n"], "\n", $request->members);
         $member_ids = explode("\n", $member_ids);
         $member_ids = array_unique(array_filter($member_ids, "strlen"));

--- a/app/Http/Controllers/Staff/Forms/Answers/CreateAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/CreateAction.php
@@ -31,7 +31,7 @@ class CreateAction extends Controller
                 ->with('url', route('staff.forms.answers.create', ['form' => $form]))
                 ->with('circles', $circles);
         } else {
-            $circle = Circle::findOrFail($request->circle);
+            $circle = Circle::submitted()->findOrFail($request->circle);
         }
 
         $answers = $this->answersService->getAnswersByCircle($form, $circle);

--- a/app/Http/Controllers/Staff/Forms/Answers/CreateAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/CreateAction.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Forms\Answers;
+
+use Auth;
+use Gate;
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Eloquents\Form;
+use App\Eloquents\Circle;
+use App\Services\Forms\AnswersService;
+
+class CreateAction extends Controller
+{
+    private $answersService;
+
+    public function __construct(AnswersService $answersService)
+    {
+        $this->answersService = $answersService;
+    }
+
+    public function __invoke(Form $form, Request $request)
+    {
+        $circle = null;
+        if (empty($request->circle)) {
+            $circles = Circle::all();
+            return view('v2.circles.selector')
+                ->with('url', route('staff.forms.answers.create', ['form' => $form]))
+                ->with('circles', $circles);
+        } else {
+            $circle = Circle::findOrFail($request->circle);
+        }
+
+        // すでに回答済だった場合
+        $answers = $this->answersService->getAnswersByCircle($form, $circle);
+        if ($form->max_answers === 1 && count($answers) === 1) {
+            // 最大回答回数 1 かつ 現時点での回答数が 1 の場合に限り、
+            // 編集画面へリダイレクトする。
+            // （それ以外の場合、View にて、回答編集も可能な旨を表示する）
+            return redirect()
+                ->route('staff.forms.answers.edit', ['form' => $form, 'answer' => $answers[0]]);
+        }
+
+        return view('v2.staff.forms.answers.form')
+            ->with('circle', $circle)
+            ->with('answers', $answers)
+            ->with('form', $form)
+            ->with('questions', $form->questions()->get());
+    }
+}

--- a/app/Http/Controllers/Staff/Forms/Answers/CreateAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/CreateAction.php
@@ -21,6 +21,11 @@ class CreateAction extends Controller
 
     public function __invoke(Form $form, Request $request)
     {
+        // カスタムフォームの編集は許可しない
+        if (isset($form->customForm)) {
+            abort(404);
+        }
+
         $circle = null;
         if (empty($request->circle)) {
             $circles = Circle::all();

--- a/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
@@ -30,7 +30,7 @@ class EditAction extends Controller
             return;
         }
 
-        $circle = $answer->circle()->withoutGlobalScope('approved')->first();
+        $circle = $answer->circle()->first();
         return view('v2.staff.forms.answers.form')
             ->with('circle', $circle)
             ->with('form', $form)

--- a/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
@@ -23,10 +23,8 @@ class EditAction extends Controller
         $this->answerDetailsService = $answerDetailsService;
     }
 
-    public function __invoke(int $form_id, Answer $answer)
+    public function __invoke(Form $form, Answer $answer)
     {
-        // カスタムフォームの編集はできるようにする
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
         if ($form->id !== $answer->form_id) {
             abort(404);
             return;

--- a/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
@@ -23,14 +23,16 @@ class EditAction extends Controller
         $this->answerDetailsService = $answerDetailsService;
     }
 
-    public function __invoke(Form $form, Answer $answer)
+    public function __invoke(int $form_id, Answer $answer)
     {
+        // カスタムフォームの編集はできるようにする
+        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
         if ($form->id !== $answer->form_id) {
             abort(404);
             return;
         }
 
-        $circle = $answer->circle;
+        $circle = $answer->circle()->withoutGlobalScope('approved')->first();
         return view('v2.staff.forms.answers.form')
             ->with('circle', $circle)
             ->with('form', $form)

--- a/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Forms\Answers;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Eloquents\Form;
+use App\Eloquents\Circle;
+use App\Eloquents\Answer;
+use App\Services\Forms\AnswersService;
+use App\Services\Forms\AnswerDetailsService;
+
+class EditAction extends Controller
+{
+    private $answersService;
+    private $answerDetailsService;
+
+    public function __construct(
+        AnswersService $answersService,
+        AnswerDetailsService $answerDetailsService
+    ) {
+        $this->answersService = $answersService;
+        $this->answerDetailsService = $answerDetailsService;
+    }
+
+    public function __invoke(Form $form, Answer $answer)
+    {
+        if ($form->id !== $answer->form_id) {
+            abort(404);
+            return;
+        }
+
+        $circle = $answer->circle;
+        return view('v2.staff.forms.answers.form')
+            ->with('circle', $circle)
+            ->with('form', $form)
+            ->with('questions', $form->questions()->get())
+            ->with('answers', $this->answersService->getAnswersByCircle($form, $circle))
+            ->with('answer', $answer)
+            ->with('answer_details', $this->answerDetailsService->getAnswerDetailsByAnswer($answer));
+    }
+}

--- a/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/EditAction.php
@@ -30,7 +30,7 @@ class EditAction extends Controller
             return;
         }
 
-        $circle = $answer->circle()->first();
+        $circle = $answer->circle()->submitted()->firstOrFail();
         return view('v2.staff.forms.answers.form')
             ->with('circle', $circle)
             ->with('form', $form)

--- a/app/Http/Controllers/Staff/Forms/Answers/NotAnswered/ShowAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/NotAnswered/ShowAction.php
@@ -10,6 +10,10 @@ class ShowAction extends Controller
 {
     public function __invoke(Form $form)
     {
+        if (isset($form->customForm)) {
+            abort(404);
+        }
+
         $circles = $form->notAnswered();
 
         return view('v2.staff.forms.answers.notanswered.index')

--- a/app/Http/Controllers/Staff/Forms/Answers/StoreAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/StoreAction.php
@@ -28,7 +28,7 @@ class StoreAction extends Controller
             abort(404);
         }
 
-        $circle = Circle::findOrFail($request->circle_id);
+        $circle = Circle::submitted()->findOrFail($request->circle_id);
         $answer = $this->answersService->createAnswer($form, $circle, $request);
         if ($answer) {
             if ($form->is_public) {

--- a/app/Http/Controllers/Staff/Forms/Answers/StoreAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/StoreAction.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Forms\Answers;
+
+use Auth;
+use App\Http\Controllers\Controller;
+use App\Eloquents\Form;
+use App\Eloquents\Circle;
+use App\Http\Requests\Staff\Forms\AnswerRequest;
+use App\Services\Forms\AnswersService;
+
+class StoreAction extends Controller
+{
+    /**
+     * @var AnswersService
+     */
+    private $answersService;
+
+    public function __construct(AnswersService $answersService)
+    {
+        $this->answersService = $answersService;
+    }
+
+    public function __invoke(Form $form, AnswerRequest $request)
+    {
+        $circle = Circle::findOrFail($request->circle_id);
+        $answer = $this->answersService->createAnswer($form, $circle, $request);
+        if ($answer) {
+            if ($form->is_public) {
+                // フォームが公開されている場合にのみ確認メールを送信する
+                $this->answersService->sendAll($answer, Auth::user(), true);
+            }
+            return redirect()
+                ->route('staff.forms.answers.edit', ['form' => $form, 'answer' => $answer])
+                ->with('topAlert.title', '回答を作成しました — 回答ID : ' . $answer->id)
+                ->with('topAlert.body', '以下のフォームより、回答を修正することもできます');
+        }
+
+        return back()
+                ->with('topAlert.type', 'danger')
+                ->with('topAlert.title', '更新に失敗しました')
+                ->with('topAlert.body', '恐れ入りますが、もう一度お試しください')
+                ->withInput();
+    }
+}

--- a/app/Http/Controllers/Staff/Forms/Answers/StoreAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/StoreAction.php
@@ -23,6 +23,11 @@ class StoreAction extends Controller
 
     public function __invoke(Form $form, AnswerRequest $request)
     {
+        // カスタムフォームの編集は許可しない
+        if (isset($form->customForm)) {
+            abort(404);
+        }
+
         $circle = Circle::findOrFail($request->circle_id);
         $answer = $this->answersService->createAnswer($form, $circle, $request);
         if ($answer) {

--- a/app/Http/Controllers/Staff/Forms/Answers/StoreAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/StoreAction.php
@@ -23,7 +23,7 @@ class StoreAction extends Controller
 
     public function __invoke(Form $form, AnswerRequest $request)
     {
-        // カスタムフォームの編集は許可しない
+        // カスタムフォームの作成は許可しない
         if (isset($form->customForm)) {
             abort(404);
         }

--- a/app/Http/Controllers/Staff/Forms/Answers/UpdateAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/UpdateAction.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Forms\Answers;
+
+use Auth;
+use App\Http\Controllers\Controller;
+use App\Eloquents\Form;
+use App\Eloquents\Circle;
+use App\Eloquents\Answer;
+use App\Http\Requests\Staff\Forms\AnswerRequest;
+use App\Services\Forms\AnswersService;
+
+class UpdateAction extends Controller
+{
+    private $answersService;
+
+    public function __construct(AnswersService $answersService)
+    {
+        $this->answersService = $answersService;
+    }
+
+    public function __invoke(Form $form, Answer $answer, AnswerRequest $request)
+    {
+        $this->answersService->updateAnswer($form, $answer, $request);
+        if ($form->is_public) {
+            // フォームが公開されている場合にのみ確認メールを送信する
+            $this->answersService->sendAll($answer, Auth::user(), true);
+        }
+        return back()
+            ->with('topAlert.title', '回答を更新しました');
+
+        // return back()
+        //         ->with('topAlert.type', 'danger')
+        //         ->with('topAlert.title', '更新に失敗しました')
+        //         ->with('topAlert.body', '恐れ入りますが、もう一度お試しください')
+        //         ->withInput();
+    }
+}

--- a/app/Http/Controllers/Staff/Forms/Answers/UpdateAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/UpdateAction.php
@@ -19,14 +19,8 @@ class UpdateAction extends Controller
         $this->answersService = $answersService;
     }
 
-    // カスタムフォームの場合、AnswerRequest の $this->route('form') で
-    // 現在のフォームを取得することができない
-    // →グローバルスコープを使うのをやめる
-    public function __invoke(int $form_id, Answer $answer, AnswerRequest $request)
+    public function __invoke(Form $form, Answer $answer, AnswerRequest $request)
     {
-        // カスタムフォームの編集はできるようにする
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
-
         $this->answersService->updateAnswer($form, $answer, $request);
         if ($form->is_public && empty($form->customForm)) {
             // フォームが公開されている場合にのみ確認メールを送信する

--- a/app/Http/Controllers/Staff/Forms/Answers/UpdateAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/UpdateAction.php
@@ -21,6 +21,9 @@ class UpdateAction extends Controller
 
     public function __invoke(Form $form, Answer $answer, AnswerRequest $request)
     {
+        // 回答に紐づく企画が参加登録未提出の場合、回答の更新を拒否する
+        $answer->circle()->submitted()->firstOrFail();
+
         $this->answersService->updateAnswer($form, $answer, $request);
         if ($form->is_public && empty($form->customForm)) {
             // フォームが公開されている場合にのみ確認メールを送信する

--- a/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
@@ -24,9 +24,7 @@ class DownloadZipAction extends Controller
     public function __invoke(Form $form)
     {
         $form->load('answers.details');
-        $form->load(['answers.circle' => function ($query) {
-            $query->withoutGlobalScope('approved');
-        }]);
+        $form->load('answers.circle');
         $form->load(['questions' => function ($query) {
             $query->where('type', 'upload');
         }]);

--- a/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/Uploads/DownloadZipAction.php
@@ -21,10 +21,8 @@ class DownloadZipAction extends Controller
         $this->downloadZipService = $downloadZipService;
     }
 
-    public function __invoke(int $form_id)
+    public function __invoke(Form $form)
     {
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
-
         $form->load('answers.details');
         $form->load(['answers.circle' => function ($query) {
             $query->withoutGlobalScope('approved');

--- a/app/Http/Controllers/Staff/Forms/Answers/Uploads/IndexAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/Uploads/IndexAction.php
@@ -8,9 +8,8 @@ use App\Eloquents\Form;
 
 class IndexAction extends Controller
 {
-    public function __invoke(int $form_id)
+    public function __invoke(Form $form)
     {
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
         return view('v2.staff.forms.answers.uploads.index')
             ->with('form', $form);
     }

--- a/app/Http/Controllers/Staff/Forms/Answers/Uploads/ShowAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/Uploads/ShowAction.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Forms\Answers\Uploads;
+namespace App\Http\Controllers\Staff\Forms\Answers\Uploads;
 
 use Storage;
 use Gate;
@@ -15,8 +15,7 @@ class ShowAction extends Controller
     public function __invoke(Request $request, int $form_id, Answer $answer, int $question_id)
     {
         // Form と Question については、DB から情報を取ってくる必要がないので、int で受け取る
-        $circle = $answer->circle()->withoutGlobalScope('approved')->first();
-        if (Gate::denies('circle.belongsTo', $circle)) {
+        if (Auth::check() && !Auth::user()->is_staff) {
             abort(404);
         }
 

--- a/app/Http/Controllers/Staff/Forms/Answers/Uploads/ShowAction.php
+++ b/app/Http/Controllers/Staff/Forms/Answers/Uploads/ShowAction.php
@@ -15,9 +15,6 @@ class ShowAction extends Controller
     public function __invoke(Request $request, int $form_id, Answer $answer, int $question_id)
     {
         // Form と Question については、DB から情報を取ってくる必要がないので、int で受け取る
-        if (Auth::check() && !Auth::user()->is_staff) {
-            abort(404);
-        }
 
         $file_path = AnswerDetail::select('answer')
             ->where('answer_id', $answer->id)

--- a/app/Http/Controllers/Staff/Forms/Editor/AddQuestionAction.php
+++ b/app/Http/Controllers/Staff/Forms/Editor/AddQuestionAction.php
@@ -16,9 +16,8 @@ class AddQuestionAction extends Controller
         $this->questionsService = $questionsService;
     }
 
-    public function __invoke(int $form_id, Request $request)
+    public function __invoke(Form $form, Request $request)
     {
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
         $question = $this->questionsService->addQuestion($form, $request->type);
         return [
             'id' => $question->id,

--- a/app/Http/Controllers/Staff/Forms/Editor/DeleteQuestionAction.php
+++ b/app/Http/Controllers/Staff/Forms/Editor/DeleteQuestionAction.php
@@ -16,9 +16,8 @@ class DeleteQuestionAction extends Controller
         $this->questionsService = $questionsService;
     }
 
-    public function __invoke(int $form_id, Request $request)
+    public function __invoke(Form $form, Request $request)
     {
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
         $question_id = (int)$request->question;
         $this->questionsService->deleteQuestion($question_id);
     }

--- a/app/Http/Controllers/Staff/Forms/Editor/GetFormAction.php
+++ b/app/Http/Controllers/Staff/Forms/Editor/GetFormAction.php
@@ -8,10 +8,8 @@ use App\Http\Controllers\Controller;
 
 class GetFormAction extends Controller
 {
-    public function __invoke(int $form_id)
+    public function __invoke(Form $form)
     {
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
-
         return [
             'id' => $form->id,
             'name' => $form->name,

--- a/app/Http/Controllers/Staff/Forms/Editor/GetQuestionsAction.php
+++ b/app/Http/Controllers/Staff/Forms/Editor/GetQuestionsAction.php
@@ -11,9 +11,8 @@ use App\Http\Controllers\Controller;
 
 class GetQuestionsAction extends Controller
 {
-    public function __invoke(int $form_id)
+    public function __invoke(Form $form)
     {
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
         $questions = $form->questions()->get();
         $questions_on_db = $questions->map(function (Question $question) {
             return [

--- a/app/Http/Controllers/Staff/Forms/Editor/IndexAction.php
+++ b/app/Http/Controllers/Staff/Forms/Editor/IndexAction.php
@@ -8,9 +8,8 @@ use App\Http\Controllers\Controller;
 
 class IndexAction extends Controller
 {
-    public function __invoke(int $form_id)
+    public function __invoke(Form $form)
     {
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
         return view('staff.forms.editor')
             ->with('form', $form);
     }

--- a/app/Http/Controllers/Staff/Forms/Editor/UpdateQuestionAction.php
+++ b/app/Http/Controllers/Staff/Forms/Editor/UpdateQuestionAction.php
@@ -18,9 +18,8 @@ class UpdateQuestionAction extends Controller
 
     // TODO: ちゃんとバリデーションする
     // TODO: is_required は null にできないよ！的な SQL エラーが発生しないようにする
-    public function __invoke(int $form_id, Request $request)
+    public function __invoke(Form $form, Request $request)
     {
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
         $question_id = (int)$request->question['id'];
         $question = $request->question;
         unset($question['created_at'], $question['updated_at'], $question['id']);

--- a/app/Http/Controllers/Staff/Forms/Editor/UpdateQuestionsOrderAction.php
+++ b/app/Http/Controllers/Staff/Forms/Editor/UpdateQuestionsOrderAction.php
@@ -16,9 +16,8 @@ class UpdateQuestionsOrderAction extends Controller
         $this->questionsService = $questionsService;
     }
 
-    public function __invoke(int $form_id, Request $request)
+    public function __invoke(Form $form, Request $request)
     {
-        $form = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
         $this->questionsService->updateQuestionsOrder(
             $form,
             collect($request->questions)->mapWithKeys(function ($question) {

--- a/app/Http/Controllers/Users/DeleteAction.php
+++ b/app/Http/Controllers/Users/DeleteAction.php
@@ -11,7 +11,7 @@ class DeleteAction extends Controller
     public function __invoke()
     {
         $user = Auth::user();
-        $circles = $user->circles()->withoutGlobalScope('approved')->get();
+        $circles = $user->circles()->get();
 
         return view('v2.users.delete')
             ->with('belong', !empty($circles));

--- a/app/Http/Controllers/Users/DestroyAction.php
+++ b/app/Http/Controllers/Users/DestroyAction.php
@@ -13,7 +13,7 @@ class DestroyAction extends Controller
     {
         $user = User::find(Auth::id());
 
-        $circles = $user->circles()->withoutGlobalScope('approved')->all();
+        $circles = $user->circles()->all();
 
         if (!empty($circles)) {
             return redirect()

--- a/app/Http/Controllers/Users/EditInfoAction.php
+++ b/app/Http/Controllers/Users/EditInfoAction.php
@@ -14,6 +14,6 @@ class EditInfoAction extends Controller
         $user = User::find(Auth::id());
         return view('v2.users.edit')
             ->with('user', $user)
-            ->with('circles', $user->circles()->withoutGlobalScope('approved')->get());
+            ->with('circles', $user->circles()->get());
     }
 }

--- a/app/Http/Requests/Forms/StoreAnswerRequest.php
+++ b/app/Http/Requests/Forms/StoreAnswerRequest.php
@@ -19,7 +19,7 @@ class StoreAnswerRequest extends BaseAnswerRequest
     {
         $answersService = App::make(AnswersService::class);
         $form = $this->route('form');
-        $circle = Circle::findOrFail($this->circle_id);
+        $circle = Circle::approved()->findOrFail($this->circle_id);
         $answers = $answersService->getAnswersByCircle($form, $circle);
         return Gate::allows('circle.belongsTo', $circle) &&
             $form->is_public && $form->isOpen() && $form->max_answers > count($answers);

--- a/app/Http/Requests/Staff/Forms/AnswerRequest.php
+++ b/app/Http/Requests/Staff/Forms/AnswerRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Staff\Forms;
+
+use App\Http\Requests\Forms\BaseAnswerRequest;
+
+class AnswerRequest extends BaseAnswerRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+}

--- a/app/Http/Requests/Users/ChangeInfoRequest.php
+++ b/app/Http/Requests/Users/ChangeInfoRequest.php
@@ -75,7 +75,7 @@ class ChangeInfoRequest extends FormRequest
     public function withValidator($validator)
     {
         $user = Auth::user();
-        $circles = $user->circles()->withoutGlobalScope('approved')->get();
+        $circles = $user->circles()->get();
         if (!empty($circles)) {
             $validator->after(function ($validator) use ($user) {
                 if (!empty($this->name) && $this->name !== $user->name) {

--- a/app/Mail/Forms/AnswerConfirmationMailable.php
+++ b/app/Mail/Forms/AnswerConfirmationMailable.php
@@ -60,6 +60,13 @@ class AnswerConfirmationMailable extends Mailable
     public $answer_details;
 
     /**
+     * スタッフによって回答が編集されたことを伝えるための確認メールであるか
+     *
+     * @var bool
+     */
+    public $isEditedByStaff;
+
+    /**
      * Create a new message instance.
      *
      * @return void
@@ -70,7 +77,8 @@ class AnswerConfirmationMailable extends Mailable
         Circle $circle,
         User $applicant,
         Answer $answer,
-        array $answer_details
+        array $answer_details,
+        bool $isEditedByStaff
     ) {
         $this->form = $form;
         $this->questions = $questions;
@@ -78,6 +86,7 @@ class AnswerConfirmationMailable extends Mailable
         $this->applicant = $applicant;
         $this->answer = $answer;
         $this->answer_details = $answer_details;
+        $this->isEditedByStaff = $isEditedByStaff;
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,20 +17,6 @@ class RouteServiceProvider extends ServiceProvider
     protected $namespace = 'App\Http\Controllers';
 
     /**
-     * Define your route model bindings, pattern filters, etc.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        parent::boot();
-
-        Route::bind('circle', function ($id) {
-            return \App\Eloquents\Circle::withoutGlobalScopes()->where('circles.id', $id)->firstOrFail();
-        });
-    }
-
-    /**
      * Define the routes for the application.
      *
      * @return void

--- a/app/Services/Forms/AnswerDetailsService.php
+++ b/app/Services/Forms/AnswerDetailsService.php
@@ -6,6 +6,7 @@ namespace App\Services\Forms;
 
 use App\Eloquents\Form;
 use App\Eloquents\Answer;
+use App\Eloquents\Question;
 use App\Eloquents\AnswerDetail;
 use App\Http\Requests\Forms\AnswerRequestInterface;
 use Storage;
@@ -30,7 +31,7 @@ class AnswerDetailsService
         foreach ($raw_details as $raw_detail) {
             $question = $answer->form->questions->firstWhere('id', $raw_detail->question_id);
 
-            if ($question->type === 'checkbox') {
+            if ($question instanceof Question && $question->type === 'checkbox') {
                 if (empty($result[$raw_detail->question_id]) || !is_array($result[$raw_detail->question_id])) {
                     $result[$raw_detail->question_id] = [];
                 }

--- a/app/Services/Forms/AnswerDetailsService.php
+++ b/app/Services/Forms/AnswerDetailsService.php
@@ -22,9 +22,7 @@ class AnswerDetailsService
     public function getAnswerDetailsByAnswer(Answer $answer)
     {
         $raw_details = AnswerDetail::where('answer_id', $answer->id)->get();
-        $answer->loadMissing(['form' => function ($query) {
-            $query->withoutGlobalScope('withoutCustomForms');
-        }], 'form.questions');
+        $answer->loadMissing('form', 'form.questions');
         $result = [];
 
         // チェックボックスの設問については、回答が配列になるようにする

--- a/app/Services/Forms/AnswerDetailsService.php
+++ b/app/Services/Forms/AnswerDetailsService.php
@@ -48,11 +48,15 @@ class AnswerDetailsService
      * 置き換えた $answer_details 配列を return する
      *
      * @param Form $form
-     * @param AnswerRequestInterface $request
+     * @param AnswerRequestInterface|null $request
      * @return array
      */
-    public function getAnswerDetailsWithFilePathFromRequest(Form $form, AnswerRequestInterface $request)
+    public function getAnswerDetailsWithFilePathFromRequest(Form $form, ?AnswerRequestInterface $request = null)
     {
+        if (empty($request)) {
+            return [];
+        }
+
         $form->loadMissing('questions');
         $answer_details = $request->validated()['answers'] ?? [];
         foreach ($form->questions as $question) {

--- a/app/Services/Forms/AnswersService.php
+++ b/app/Services/Forms/AnswersService.php
@@ -18,6 +18,9 @@ use Illuminate\Support\Facades\Mail;
 
 class AnswersService
 {
+    /**
+     * @var AnswerDetailsService
+     */
     private $answerDetailsService;
 
     public function __construct(AnswerDetailsService $answerDetailsService)
@@ -121,7 +124,7 @@ class AnswersService
         return Answer::where('form_id', $form->id)->where('circle_id', $circle->id)->get();
     }
 
-    public function createAnswer(Form $form, Circle $circle, AnswerRequestInterface $request)
+    public function createAnswer(Form $form, Circle $circle, ?AnswerRequestInterface $request = null)
     {
         return DB::transaction(function () use ($form, $circle, $request) {
             $answer_details = $this->answerDetailsService->getAnswerDetailsWithFilePathFromRequest($form, $request);
@@ -137,7 +140,7 @@ class AnswersService
         });
     }
 
-    public function updateAnswer(Form $form, Answer $answer, AnswerRequestInterface $request)
+    public function updateAnswer(Form $form, Answer $answer, ?AnswerRequestInterface $request = null)
     {
         return DB::transaction(function () use ($form, $answer, $request) {
             $answer_details = $this->answerDetailsService->getAnswerDetailsWithFilePathFromRequest($form, $request);

--- a/app/Services/Forms/FormsService.php
+++ b/app/Services/Forms/FormsService.php
@@ -17,7 +17,7 @@ class FormsService
      */
     public function updateForm(int $form_id, array $form)
     {
-        $eloquent = Form::withoutGlobalScope('withoutCustomForms')->findOrFail($form_id);
+        $eloquent = Form::findOrFail($form_id);
         $form['open_at'] = new Carbon($form['open_at']);
         $form['close_at'] = new Carbon($form['close_at']);
         $eloquent->fill($form);

--- a/application/controllers/Home_staff.php
+++ b/application/controllers/Home_staff.php
@@ -336,14 +336,14 @@ class Home_staff extends MY_Controller
     private function _application_read_csv($vars)
     {
         // カラム名
-        $string_to_export = "ID\t企画ID\t企画の名前";
+        $string_to_export = "ID\t企画ID\t企画の名前\t企画の名前(よみ)\t企画団体の名前\t企画団体の名前(よみ)";
 
         if ($vars["form"]->type === "booth") {
             $string_to_export .= "\tブース名";
         }
 
-        $string_to_export .= "\t作成日時";
-        $string_to_export .= "\t更新日時";
+        $string_to_export .= "\t回答作成日時";
+        $string_to_export .= "\t回答更新日時";
 
         foreach ($vars["form"]->questions as $question) {
             if ($question->type !== 'heading') {
@@ -361,6 +361,12 @@ class Home_staff extends MY_Controller
             $string_to_export .= "\t" . $answer->circle->id;
             // 企画の名前
             $string_to_export .= "\t" . $answer->circle->name;
+            // 企画の名前(よみ)
+            $string_to_export .= "\t" . $answer->circle->name_yomi;
+            // 企画団体の名前
+            $string_to_export .= "\t" . $answer->circle->group_name;
+            // 企画団体の名前(よみ)
+            $string_to_export .= "\t" . $answer->circle->group_name_yomi;
             // ブース名
             if ($vars["form"]->type === "booth") {
                 $string_to_export .= "\t" . $answer->booth->place_name;

--- a/application/views/home_staff/home_staff.applications_read.html.twig
+++ b/application/views/home_staff/home_staff.applications_read.html.twig
@@ -263,8 +263,9 @@
                             ・ ブース
                         {% endif %}
                     </th>
-                    <th>作成日時</th>
-                    <th>更新日時</th>
+                    <th>企画団体</th>
+                    <th>回答作成日時</th>
+                    <th>回答更新日時</th>
                     {% for question in form.questions if question.type is not same as("heading") %}
                         <th>
                             {{ question.name }}
@@ -288,7 +289,10 @@
                         <td>{{ answer.id }}</td>
                         <th class="table-sticky">
                             <a href="{{ base_url("home_staff/circles/read/#{answer.circle_id}") }}">
+                              <ruby>
                                 {{ answer.circle.name }}
+                                <rt>{{ answer.circle.name_yomi }}</rt>
+                              </ruby>
                             </a>
                             (ID : {{ answer.circle.id }})
                             {% if form.type == "booth" %}
@@ -298,6 +302,12 @@
                                 </a>
                             {% endif %}
                         </th>
+                        <td>
+                          <ruby>
+                            {{ answer.circle.group_name }}
+                            <rt>{{ answer.circle.group_name_yomi }}</rt>
+                          </ruby>
+                        </td>
                         <td>{{ answer.created_at }}</td>
                         <td>{{ answer.updated_at }}</td>
                         {% for question in form.questions if question.type is not same as("heading") %}

--- a/application/views/home_staff/home_staff.applications_read.html.twig
+++ b/application/views/home_staff/home_staff.applications_read.html.twig
@@ -357,7 +357,7 @@
                 {% endfor %}
                 </tbody>
             </table>
-            {% if form.questions is empty %}
+            {% if answers is empty %}
             <div class="well well-sm text-center lead text-muted" style="margin-bottom: 0; padding: 3rem 0;">
                 まだ回答はありません
             </div>

--- a/application/views/home_staff/home_staff.applications_read.html.twig
+++ b/application/views/home_staff/home_staff.applications_read.html.twig
@@ -15,6 +15,10 @@
             margin-top: .5rem;
         }
 
+        .applications-read-name small {
+          font-size: 1.25rem;
+        }
+
         .applications-read-send-email {
             padding-left: 40px;
             padding-right: 40px;
@@ -113,6 +117,11 @@
                 <div class="col-md-6 applications-read-header-main">
                     <h1 class="applications-read-name">
                         {{ form.name }}
+                        {% if (form.is_public == 0) %}
+                            <small class="label label-danger">非公開</small>
+                        {% else %}
+                            <small class="label label-success">公開</small>
+                        {% endif %}
                     </h1>
                     <p class="text-muted">
                         受付期間 :
@@ -126,11 +135,6 @@
                           <a href="{{ public_form_url }}" target="_blank" rel="noopener">
                               {{ public_form_url }}
                           </a>
-                        {% endif %}
-                        {% if (form.is_public == 0) %}
-                            <span class="label label-danger">非公開</span>
-                        {% else %}
-                            <span class="label label-success">公開</span>
                         {% endif %}
                     </p>
                     {% if form.description_html is not empty %}
@@ -222,6 +226,14 @@
             <h2 class="panel-title">回答一覧</h2>
         </div>
         <div class="panel-body">
+          {% if form.custom_form is empty %}
+                <div class="pull-left">
+                    <a href="{{ base_url("/staff/forms/#{form.id}/answers/create") }}" class="btn btn-primary">
+                        <span class="fa fa-plus" aria-hidden="true"></span>
+                        新しい回答を作成
+                    </a>
+                </div>
+            {% endif %}
             <div class="pull-right">
                 <a href="{{ base_url("/staff/forms/#{form.id}/answers/uploads") }}" class="btn btn-primary">
                     <span class="fa fa-file-archive-o" aria-hidden="true"></span>
@@ -264,9 +276,13 @@
                 {% for answer in answers %}
                     <tr>
                         <td>
+                            <a href="{{ base_url("staff/forms/#{form.id}/answers/#{answer.id}/edit") }}"
+                              class="btn btn-primary">
+                              <span class="fa fa-pencil" aria-hidden="true"></span>
+                            </a>
                             <a href="{{ base_url("home_staff/applications_answer_read/#{answer.id}") }}"
-                               class="btn btn-info">
-                                <span class="fa fa-eye" aria-hidden="true"></span>
+                              class="btn btn-info">
+                              <span class="fa fa-eye" aria-hidden="true"></span>
                             </a>
                         </td>
                         <td>{{ answer.id }}</td>
@@ -323,7 +339,7 @@
                                         {% if answer.answers[question.id] is not empty %}
                                             <a href="{{
                                                 strpos(answer.answers[question.id], 'answer_details') is same as(0)
-                                                      ? base_url( "forms/#{form.id}/answers/#{answer.id}/uploads/#{question.id}" )
+                                                      ? base_url( "staff/forms/#{form.id}/answers/#{answer.id}/uploads/#{question.id}" )
                                                       : base_url( "uploads/applications_form/#{answer.answers[question.id]}" )
                                               }}"
                                               target="_blank">{{ str_replace('answer_details/', 'answer_details__', answer.answers[question.id]) }}</a>
@@ -341,6 +357,11 @@
                 {% endfor %}
                 </tbody>
             </table>
+            {% if form.questions is empty %}
+            <div class="well well-sm text-center lead text-muted" style="margin-bottom: 0; padding: 3rem 0;">
+                まだ回答はありません
+            </div>
+            {% endif %}
         </div>
     </section>
 

--- a/application/views/home_staff/home_staff.applications_read_print.html.twig
+++ b/application/views/home_staff/home_staff.applications_read_print.html.twig
@@ -74,6 +74,7 @@
                         ・ ブース
                     {% endif %}
                 </th>
+                <th>企画団体</th>
                 {% for question in form.questions if question.type is not same as ("heading") %}
                     <th>
                         {{ question.name }}
@@ -86,12 +87,22 @@
                 <tr>
                     <td>{{ answer.id }}</td>
                     <th class="table-sticky">
-                        {{ answer.circle.name }} (ID : {{ answer.circle.id }})
-                        {% if form.type == "booth" %}
-                            <br>
-                            {{ answer.booth.place_name }}
-                        {% endif %}
+                      <ruby>
+                        {{ answer.circle.name }}
+                        <rt>{{ answer.circle.name_yomi }}</rt>
+                      </ruby>
+                      (ID : {{ answer.circle.id }})
+                      {% if form.type == "booth" %}
+                        <br>
+                        {{ answer.booth.place_name }}
+                      {% endif %}
                     </th>
+                    <td>
+                      <ruby>
+                        {{ answer.circle.group_name }}
+                        <rt>{{ answer.circle.group_name_yomi }}</rt>
+                      </ruby>
+                    </td>
                     {% for question in form.questions if question.type is not same as("heading") %}
                         <td class="applications-read-answer-td">
                             <div class="applications-read-answer-td__inner">

--- a/application/views/home_staff/home_staff.applications_read_print.html.twig
+++ b/application/views/home_staff/home_staff.applications_read_print.html.twig
@@ -108,7 +108,7 @@
                                     {% if answer.answers[question.id] is not empty %}
                                         <a href="{{
                                             strpos(answer.answers[question.id], 'answer_details') is same as(0)
-                                                  ? base_url( "forms/#{form.id}/answers/#{answer.id}/uploads/#{question.id}" )
+                                                  ? base_url( "staff/forms/#{form.id}/answers/#{answer.id}/uploads/#{question.id}" )
                                                   : base_url( "uploads/applications_form/#{answer.answers[question.id]}" )
                                           }}"
                                           target="_blank">{{ answer.answers[question.id] }}</a>

--- a/application/views/layouts/macro_applications_form.html.twig
+++ b/application/views/layouts/macro_applications_form.html.twig
@@ -147,7 +147,7 @@
                         |
                         <a href="{{
                           strpos(answers[question.id], 'answer_details') is same as(0)
-                                ? base_url( "forms/#{form.id}/answers/#{answer_info.id}/uploads/#{question.id}" )
+                                ? base_url( "staff/forms/#{form.id}/answers/#{answer_info.id}/uploads/#{question.id}" )
                                 : base_url( "uploads/applications_form/#{answers[question.id]}" )
                         }}" target="_blank">
                             アップロードされたファイルを表示...

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "prod": "npm run production",
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "eslint-check": "eslint --ext js,vue ./resources",
-        "stylelint-check": "stylelint ./resources/**/*.{vue,scss}"
+        "stylelint-check": "stylelint ./resources/**/*.{vue,scss}",
+        "phpunit": "cd docker_dev && docker-compose run web ./vendor/bin/phpunit"
     },
     "lint-staged": {
         "*.js": [

--- a/resources/js/forms_editor/store/api/repository.js
+++ b/resources/js/forms_editor/store/api/repository.js
@@ -5,7 +5,9 @@ const baseURL = document.querySelector('#forms-editor-config')
       document.querySelector('#forms-editor-config').dataset.apiBaseUrl
     )
   : null
-const token = document.head.querySelector('meta[name="csrf-token"]').content
+const token = document.head.querySelector('meta[name="csrf-token"]')
+  ? document.head.querySelector('meta[name="csrf-token"]').content
+  : null
 
 const axios = Axios.create({
   baseURL,

--- a/resources/views/emails/forms/answer_confirmation.blade.php
+++ b/resources/views/emails/forms/answer_confirmation.blade.php
@@ -1,12 +1,16 @@
 @component('mail::message')
 # {{ $form->name }}
+@if ($isEditedByStaff)
+スタッフによって申請「{{ $form->name }}」が作成・編集されましたのでお知らせします。
+@else
 申請「{{ $form->name }}」を承りました。
+@endif
 
 @component('mail::panel')
 - 回答ID : {{ $answer->id }}
 - 企画の名前 : {{ $circle->name }}
 - 企画団体の名前 : {{ $circle->group_name }}
-- 回答者 : {{ $applicant->name }}
+- 回答者 : {{ $isEditedByStaff ? 'スタッフ' : $applicant->name }}
 - 日時 : @datetime($answer->updated_at)
 @endcomponent
 
@@ -38,10 +42,12 @@
 
 <br /><br />
 
+@if ($form->isOpen())
 @component('mail::panel')
 フォームの受付期間内であれば、回答を変更することもできます。
 @component('mail::button', ['url' => route('forms.answers.edit', ['form' => $form, 'answer' => $answer]), 'color' => 'primary'])
 回答を変更
 @endcomponent
 @endcomponent
+@endif
 @endcomponent

--- a/resources/views/staff/circles/form.blade.php
+++ b/resources/views/staff/circles/form.blade.php
@@ -83,16 +83,25 @@
                         </div>
                     </div>
                     <hr>
-                    <div class="form-group row">
-                        <span class="col-sm-2 col-form-label">カスタムフォームへの回答</span>
-                        <div class="col-sm-10">
-                            <p>
-                                <i class="fa fa-info-circle fa-fw" aria-hidden="true"></i>
-                                この画面ではまだカスタムフォームの回答を表示・編集できません。今後のアップデートでカスタムフォームの表示・編集もこの画面で可能にする予定です。
-                            </p>
+                    @if (isset($custom_form))
+                        <div class="form-group row">
+                            <span class="col-sm-2 col-form-label">カスタムフォームへの回答</span>
+                            <div class="col-sm-10">
+                                @empty ($circle)
+                                    <p>
+                                        <i class="fa fa-info-circle fa-fw" aria-hidden="true"></i>
+                                        カスタムフォーム回答の内容を編集するには、まず企画情報を保存してください
+                                    </p>
+                                @else
+                                    <a href="{{ route('staff.forms.answers.create', ['form' => $custom_form, 'circle' => $circle]) }}"
+                                        class="btn btn-primary">
+                                        カスタムフォーム回答の内容を表示・編集
+                                    </a>
+                                @endempty
+                            </div>
                         </div>
-                    </div>
-                    <hr>
+                        <hr>
+                    @endif
                     <div class="form-group row">
                         <div class="col-sm-2 col-form-label">参加登録受理</div>
                         <div class="col-sm-10">

--- a/resources/views/v2/circles/selector.blade.php
+++ b/resources/views/v2/circles/selector.blade.php
@@ -1,7 +1,8 @@
-@extends('v2.layouts.app')
+{{-- TODO: 将来的には、スタッフモード専用のドロワーが表示されるようにしたい --}}
+@extends(Request::is('staff*') ? 'v2.layouts.no_drawer' : 'v2.layouts.app')
 
 @section('title', '企画を選択')
-    
+
 @section('content')
     <app-container>
         <list-view>

--- a/resources/views/v2/forms/answers/form.blade.php
+++ b/resources/views/v2/forms/answers/form.blade.php
@@ -46,7 +46,7 @@
                 <list-view-item>
                     <template v-slot:title>申請企画名</template>
                     {{ $circle->name }}
-                    @if (count(Auth::user()->circles) > 1)
+                    @if (Auth::user()->circles()->approved()->count() > 1)
                         {{-- TODO: あとでもうちょっといい感じのコードに書き直す --}}
                         —
                         <a href="{{ route('forms.answers.create', ['form' => $form]) }}">変更</a>

--- a/resources/views/v2/includes/question.blade.php
+++ b/resources/views/v2/includes/question.blade.php
@@ -8,7 +8,7 @@
     {{-- 【v-bind:question-id の値について】 --}}
     {{-- Vue に String ではなく Number 型であると認識させるため --}}
     {{-- v-bind を利用 --}}
-    
+
     {{-- 【v-bind:value の値について】 --}}
     {{-- ファイルアップロード済の場合は、アップロードしたファイルにアクセスできるURLをvalueに設定 --}}
     <question-item @if ($question->is_required)
@@ -16,7 +16,7 @@
         @endif
         @if ($question->type === 'upload' && !empty($answer) &&
             !empty($answer_details[$question->id]))
-            value="{{ strpos($answer_details[$question->id], 'answer_details') === 0 ? route('forms.answers.uploads.show', ['form' => $form, 'answer' => $answer, 'question' => $question]) : url('/uploads/applications_form/' . $answer_details[$question->id]) }}"
+            value="{{ strpos($answer_details[$question->id], 'answer_details') === 0 ? route($show_upload_route ?? 'forms.answers.uploads.show', ['form' => $form, 'answer' => $answer, 'question' => $question]) : url('/uploads/applications_form/' . $answer_details[$question->id]) }}"
         @else
             v-bind:value="{{ json_encode(old('answers.' . $question->id, $answer_details[$question->id] ?? null)) }}"
         @endif

--- a/resources/views/v2/staff/forms/answers/form.blade.php
+++ b/resources/views/v2/staff/forms/answers/form.blade.php
@@ -66,7 +66,7 @@
                 <list-view>
                     <template v-slot:title>以前の回答を閲覧・変更</template>
                     @foreach ($answers as $_)
-                        <list-view-item href="{{ route('forms.answers.edit', ['form' => $form, 'answer' => $_]) }}">
+                        <list-view-item href="{{ route('staff.forms.answers.edit', ['form' => $form, 'answer' => $_]) }}">
                             <template v-slot:title>
                                 @datetime($_->created_at) に新規作成した回答 — 回答ID : {{ $_->id }}
                             </template>

--- a/resources/views/v2/staff/forms/answers/form.blade.php
+++ b/resources/views/v2/staff/forms/answers/form.blade.php
@@ -1,0 +1,103 @@
+@extends('v2.layouts.no_drawer')
+
+@section('title', $form->name . ' — 申請')
+
+@section('navbar')
+    @if (!empty($answer) && count($answers) > 0 && $form->max_answers > 1)
+        <app-nav-bar-back inverse href="{{ route('staff.forms.answers.create', ['form' => $form, 'circle' => $circle]) }}">
+            回答の新規作成
+        </app-nav-bar-back>
+    @else
+        <app-nav-bar-back inverse href="{{ url('/home_staff/applications/read/' . $form->id) }}" data-turbolinks="false">
+            {{ $form->name }}
+        </app-nav-bar-back>
+    @endif
+@endsection
+
+@section('content')
+    <form method="post"
+        action="{{ empty($answer) ? route('staff.forms.answers.store', [$form]) : route('staff.forms.answers.update', [$form, $answer]) }}"
+        enctype="multipart/form-data">
+        @csrf
+
+        @method(empty($answer) ? 'post' : 'patch' )
+
+        <input type="hidden" name="circle_id" value="{{ $circle->id }}">
+
+        <app-header>
+            <template v-slot:title>{{ $form->name }}</template>
+            <div class="markdown">
+                @markdown($form->description)
+            </div>
+        </app-header>
+
+        <app-container>
+            <list-view>
+                <list-view-item>
+                    <template v-slot:title>申請企画名</template>
+                    {{ $circle->name }}
+                    —
+                    {{-- TODO: あとでもうちょっといい感じのコードに書き直す --}}
+                    <a href="{{ route('staff.forms.answers.create', ['form' => $form]) }}">変更</a>
+                </list-view-item>
+                <list-view-card>
+                    @if ($form->is_public)
+                        <div class="text-danger">
+                            <i class="fas fa-info-circle"></i>
+                            スタッフとして回答します。この画面で回答を作成・編集すると、企画のメンバーには「スタッフによって回答が作成・編集された」という旨のメールが送信されます。
+                        </div>
+                    @else
+                        <div class="text-muted">
+                            <i class="fas fa-info-circle"></i>
+                            非公開フォームのため、この画面で回答を作成・編集しても、その旨は企画のメンバーに通知されません。
+                        </div>
+                    @endif
+                </list-view-card>
+            </list-view>
+
+            {{-- $answers ← 企画 $circle が回答した全回答（回答新規作成画面で使用。変更画面でも使用可能） --}}
+            {{-- $answer ← 編集対象の回答（回答変更画面で使用） --}}
+
+            @if (empty($answer) && count($answers) > 0)
+                <list-view>
+                    <template v-slot:title>以前の回答を閲覧・変更</template>
+                    @foreach ($answers as $_)
+                        <list-view-item href="{{ route('forms.answers.edit', ['form' => $form, 'answer' => $_]) }}">
+                            <template v-slot:title>
+                                @datetime($_->created_at) に新規作成した回答 — 回答ID : {{ $_->id }}
+                            </template>
+                            @unless ($_->created_at->eq($_->updated_at))
+                                <template v-slot:meta>回答の最終更新日時 : @datetime($_->updated_at)</template>
+                            @endunless
+                        </list-view-item>
+                    @endforeach
+                </list-view>
+            @endif
+
+            <list-view>
+
+                @if (empty($answer))
+                    <template v-slot:title>回答を新規作成</template>
+                @endif
+                @isset ($answer)
+                    <template v-slot:title>回答を編集 — 回答ID : {{ $answer->id }}</template>
+                    <template v-slot:description>回答の最終更新日時 : @datetime($form->updated_at)</template>
+                @endisset
+
+                @foreach ($questions as $question)
+                    @include('v2.includes.question', ['show_upload_route' => 'staff.forms.answers.uploads.show'])
+                @endforeach
+            </list-view>
+
+            <div class="text-center pt-spacing-md pb-spacing">
+                <button type="submit" class="btn is-primary is-wide">送信</button>
+                @if (config('app.debug'))
+                    <button type="submit" class="btn is-primary-inverse" formnovalidate>
+                        <strong class="badge is-primary">開発モード</strong>
+                        バリデーションせずに送信
+                    </button>
+                @endif
+            </div>
+        </app-container>
+    </form>
+@endsection

--- a/resources/views/v2/staff/forms/answers/form.blade.php
+++ b/resources/views/v2/staff/forms/answers/form.blade.php
@@ -41,7 +41,7 @@
                     <a href="{{ route('staff.forms.answers.create', ['form' => $form]) }}">変更</a>
                 </list-view-item>
                 <list-view-card>
-                    @if ($form->is_public)
+                    @if ($form->is_public && empty($form->customForm))
                         <div class="text-danger">
                             <i class="fas fa-info-circle"></i>
                             スタッフとして回答します。この画面で回答を作成・編集すると、企画のメンバーには「スタッフによって回答が作成・編集された」という旨のメールが送信されます。
@@ -49,7 +49,11 @@
                     @else
                         <div class="text-muted">
                             <i class="fas fa-info-circle"></i>
-                            非公開フォームのため、この画面で回答を作成・編集しても、その旨は企画のメンバーに通知されません。
+                            @if (isset($form->customForm))
+                                この画面で回答を作成・編集しても、その旨は企画のメンバーに通知されません。
+                            @else
+                                非公開フォームのため、この画面で回答を作成・編集しても、その旨は企画のメンバーに通知されません。
+                            @endif
                         </div>
                     @endif
                 </list-view-card>

--- a/resources/views/v2/staff/forms/answers/form.blade.php
+++ b/resources/views/v2/staff/forms/answers/form.blade.php
@@ -3,16 +3,9 @@
 @section('title', $form->name . ' — 申請')
 
 @section('navbar')
-    @if (!empty($answer) && count($answers) > 0 && $form->max_answers > 1)
-        <app-nav-bar-back inverse href="{{ route('staff.forms.answers.create', ['form' => $form, 'circle' => $circle]) }}">
-            回答の新規作成
-        </app-nav-bar-back>
-    @else
-        <app-nav-bar-back inverse href="{{ url('/home_staff/applications/read/' . $form->id) }}" data-turbolinks="false">
-            {{ $form->name }}
-        </app-nav-bar-back>
-    @endif
-@endsection
+    <app-nav-bar-back inverse href="{{ url('/home_staff/applications/read/' . $form->id) }}" data-turbolinks="false">
+        {{ $form->name }}
+    </app-nav-bar-back>
 
 @section('content')
     <form method="post"

--- a/resources/views/v2/staff/forms/answers/form.blade.php
+++ b/resources/views/v2/staff/forms/answers/form.blade.php
@@ -6,6 +6,7 @@
     <app-nav-bar-back inverse href="{{ url('/home_staff/applications/read/' . $form->id) }}" data-turbolinks="false">
         {{ $form->name }}
     </app-nav-bar-back>
+@endsection
 
 @section('content')
     <form method="post"

--- a/routes/web.php
+++ b/routes/web.php
@@ -145,6 +145,11 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
                 Route::prefix('/answers')
                     ->name('answers.')
                     ->group(function () {
+                        Route::get('/{answer}/edit', 'Staff\Forms\Answers\EditAction')->name('edit');
+                        Route::patch('/{answer}', 'Staff\Forms\Answers\UpdateAction')->name('update');
+                        Route::get('/create', 'Staff\Forms\Answers\CreateAction')->name('create');
+                        Route::post('/', 'Staff\Forms\Answers\StoreAction')->name('store');
+                        Route::get('/{answer}/uploads/{question}', 'Staff\Forms\Answers\Uploads\ShowAction')->name('uploads.show');
                         Route::get('/uploads', 'Staff\Forms\Answers\Uploads\IndexAction')->name('uploads.index');
                         Route::post('/uploads/download_zip', 'Staff\Forms\Answers\Uploads\DownloadZipAction')->name('uploads.download_zip');
                     });

--- a/tests/Feature/Http/Controllers/Forms/Answers/StoreActionTest.php
+++ b/tests/Feature/Http/Controllers/Forms/Answers/StoreActionTest.php
@@ -10,6 +10,7 @@ use Carbon\CarbonImmutable;
 use App\Eloquents\User;
 use App\Eloquents\Circle;
 use App\Eloquents\Form;
+use App\Eloquents\CustomForm;
 
 class StoreActionTest extends TestCase
 {
@@ -82,6 +83,38 @@ class StoreActionTest extends TestCase
             '受付終了後' => [new CarbonImmutable('2020-03-26 15:23:32'), false],
             '受付終了してだいぶ経過' => [new CarbonImmutable('2020-08-14 02:35:31'), false],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function カスタムフォームとして登録されているフォームには回答できない()
+    {
+        Carbon::setTestNow(new CarbonImmutable('2020-02-16 02:25:15'));
+        CarbonImmutable::setTestNow(new CarbonImmutable('2020-02-16 02:25:15'));
+
+        $customForm = factory(CustomForm::class)->create([
+            'type' => 'circle',
+            'form_id' => $this->form->id,
+        ]);
+
+        $response = $this
+                    ->actingAs($this->user)
+                    ->post(
+                        route('forms.answers.store', [
+                            'form' => $this->form->id,
+                        ]),
+                        [
+                            'circle_id' => $this->circle->id,
+                        ]
+                    );
+
+        $this->assertDatabaseMissing('answers', [
+            'form_id' => $this->form->id,
+            'circle_id' => $this->circle->id,
+        ]);
+
+        $response->assertStatus(404);
     }
 
     /**

--- a/tests/Feature/Http/Controllers/Forms/Answers/Uploads/ShowActionTest.php
+++ b/tests/Feature/Http/Controllers/Forms/Answers/Uploads/ShowActionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Forms\Answers\Uploads;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class ShowActionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function 自分が所属していない企画によるアップロードファイルはダウンロードできない()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Http/Controllers/Staff/Circles/EditActionTest.php
+++ b/tests/Feature/Http/Controllers/Staff/Circles/EditActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Staff\Circles;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Eloquents\User;
+use App\Eloquents\Circle;
+
+class EditActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $staff;
+    private $user;
+    private $circle;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->staff = factory(User::class)->states('staff')->create();
+
+        $this->user = factory(User::class)->create();
+        $this->circle = factory(Circle::class)->create();
+
+        $this->user->circles()->attach($this->circle->id, ['is_leader' => true]);
+    }
+
+    /**
+     * @test
+     */
+    public function 参加登録が未完了の企画情報は編集できない()
+    {
+        $notSubmitted = factory(Circle::class)->states('notSubmitted')->create();
+        $this->user->circles()->attach($this->circle->id, ['is_leader' => true]);
+
+        $response = $this->actingAs($this->staff)
+            ->withSession(['staff_authorized' => true])
+            ->get(route('staff.circles.edit', ['circle' => $notSubmitted]));
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Feature/Http/Controllers/Staff/Forms/Answers/Uploads/ShowActionTest.php
+++ b/tests/Feature/Http/Controllers/Staff/Forms/Answers/Uploads/ShowActionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Staff\Forms\Answers\Uploads;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\File;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use App\Eloquents\Form;
+use App\Eloquents\Question;
+use App\Eloquents\Answer;
+use App\Eloquents\AnswerDetail;
+use App\Eloquents\User;
+
+class ShowActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $form;
+    private $answer;
+    private $question;
+    private $staff;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // フォーム
+        $this->form = factory(Form::class)->create();
+        $this->question = factory(Question::class)->create([
+            'form_id' => $this->form->id,
+            'type' => 'upload',
+            'number_max' => 1000000000,
+            'allowed_types' => 'png|jpg|jpeg|gif',
+            'options' => null,
+        ]);
+
+        // 回答
+        $this->answer = factory(Answer::class)->create();
+
+        $example_file = new File(base_path('tests/TestFile.png'));
+        $filename = 'testfile_' . sha1($this->answer->id . '_' . $this->question->id) . '.png';
+        $this->answer_details[] = factory(AnswerDetail::class)->create([
+                'answer_id' => $this->answer->id,
+                'question_id' => $this->question->id,
+                'answer' => 'answer_details/' . $filename,
+            ]);
+        Storage::putFileAs('answer_details', $example_file, $filename);
+
+        // スタッフ
+        $this->staff = factory(User::class)->states('staff')->create();
+    }
+
+    /**
+     * @test
+     */
+    public function ダウンロードできる()
+    {
+        $response = $this->actingAs($this->staff)
+            ->withSession(['staff_authorized' => true])
+            ->get(route('staff.forms.answers.uploads.show', [
+                'form' => $this->form,
+                'answer' => $this->answer,
+                'question' => $this->question
+            ]));
+
+        $response->assertOk();
+    }
+
+    /**
+     * @test
+     */
+    public function スタッフ以外はダウンロードできない()
+    {
+        $response = $this->actingAs(factory(User::class)->create())
+            ->get(route('staff.forms.answers.uploads.show', [
+                'form' => $this->form,
+                'answer' => $this->answer,
+                'question' => $this->question
+            ]));
+
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## 実装内容
close #37 
<!-- どんな実装をしたのか -->

- スタッフモード内の、申請回答一覧ページ、参加登録カスタムフォーム回答一覧ページにおいて、回答を編集できるようにしました。

## 懸念点

この PR では、とりあえずスタッフモードから回答を編集できるようにしただけです。UX 的にはあまり優れていないので、別 PR で修正できればと思います。

（ただ、「こうしたほうが使う人（委員）にとって使いやすい」などあればコメントしてくれると嬉しいです！指摘をふまえて新しくissue立てます）

## レビュワーに見て欲しい点

## 参考URL
