### PR TITLE
【Turbolinks】Turbolinksによるアクセスの場合は404/403などのステータスコードを返さない #46

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -50,6 +50,17 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $exception)
     {
-        return parent::render($request, $exception);
+        $response = parent::render($request, $exception);
+
+        // ステータスコードがエラーとなるページへのアクセスは Turbolinks に
+        // 対応していないので、200 を返す
+        if (
+            !empty($request->headers->get('Turbolinks-Referrer'))
+            && in_array($response->getStatusCode(), [403, 404, 500 , 503], true)
+        ) {
+            $response->setStatusCode(200);
+        }
+
+        return $response;
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -56,7 +56,7 @@ class Handler extends ExceptionHandler
         // 対応していないので、200 を返す
         if (
             !empty($request->headers->get('Turbolinks-Referrer'))
-            && in_array($response->getStatusCode(), [403, 404, 500 , 503], true)
+            && in_array($response->getStatusCode(), [403, 404, 500, 503], true)
         ) {
             $response->setStatusCode(200);
         }


### PR DESCRIPTION
## 実装内容
close #46 
<!-- どんな実装をしたのか -->

- 今まで、404となるページへのリンクをクリックすると、画面が真っ白になっていた。このPRでは、404ページにアクセスしても、画面が真っ白にならなくなりました。

## 懸念点

## レビュワーに見て欲しい点

### 動作のチェック方法

1. 適当なページに `<a href="/staff/notFound">存在しないページへのリンク</a>` を設置する
    - リンク先は Laravel のページである必要があります
1. リンクを踏むと、ちゃんと404ページが表示されることを確認する

## 参考URL
