### PR TITLE
【Staff/ユーザー情報管理/個別表示】未提出の企画が表示される #49

### DIFF
--- a/application/models/Circles_model.php
+++ b/application/models/Circles_model.php
@@ -40,6 +40,7 @@ class Circles_model extends MY_Model
       // select * from circle_user join circles on circles.id = circle_user.circle_id where circle_user.user_id = ?
         $this->db->from("circle_user");
         $this->db->join("circles", "circles.id = circle_user.circle_id");
+        $this->db->where("circles.submitted_at !=", null);
         $this->db->where("circle_user.user_id", $user_id);
         $query = $this->db->get();
         return $query->result();

--- a/application/views/home_staff/home_staff.users_read.html.twig
+++ b/application/views/home_staff/home_staff.users_read.html.twig
@@ -128,6 +128,9 @@
       <h2 class="panel-title">このユーザーが所属する企画</h2>
     </div>
     <div class="panel-body">
+    {% if circles is empty %}
+      所属している企画はありません
+    {% else %}
       <div class="row">
         {% for circle in circles %}
           <div class="col-lg-4 col-md-6">
@@ -156,6 +159,7 @@
           </div>
         {% endfor %}
       </div>
+    {% endif %}
     </div>
   </section>
 


### PR DESCRIPTION
## 実装内容
close #49 
<!-- どんな実装をしたのか -->
- 未提出の企画を「このユーザーが所属する企画」に表示しないようにしました
- 企画の個別表示ではメンバーがいない場合に「この企画には誰も所属していません」と表示していたので、ユーザー側にも同じような表示を追加

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
