### PR TITLE
「ページの有効期限が切れました」が無限に繰り返される #96

### DIFF
--- a/resources/views/errors/layout.blade.php
+++ b/resources/views/errors/layout.blade.php
@@ -1,40 +1,41 @@
 @extends('v2.layouts.app')
 
 @hasSection ('twitter')
-@push('js')
-    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-@endpush
+    @push('js')
+        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    @endpush
 @endif
 
 @section('content')
-<app-container>
-    <div class="error">
-        <div class="error-title">
-            @yield('top')
-        </div>
-        <div class="error-message">
-            @yield('message')
-        </div>
-        @hasSection ('contact')
-            <div class="error-contact">
-                @yield('contact')
-                <p><a href="mailto:{{ config('portal.contact_email') }}">{{ config('portal.contact_email') }}</a></p>
+    <app-container>
+        <div class="error">
+            <div class="error-title">
+                @yield('top')
             </div>
-        @endif
-        @hasSection ('back')
-            <div class="error-button">
-                <button class="btn is-primary" onclick="window.history.back();">前のページに戻る</button>
+            <div class="error-message">
+                @yield('message')
             </div>
-        @endif
-        @if (!empty(config('portal.admin_twitter')))
-        @hasSection ('twitter')
-        <div class="error-twitter">
-            <a class="twitter-timeline" data-height="100%" data-chrome="noscrollbar noborders" href="https://twitter.com/{{ config('portal.admin_twitter') }}?ref_src=twsrc%5Etfw">
-                Tweets by {{ config('portal.admin_twitter') }}
-            </a>
+            @hasSection ('contact')
+                <div class="error-contact">
+                    @yield('contact')
+                    <p><a href="mailto:{{ config('portal.contact_email') }}">{{ config('portal.contact_email') }}</a></p>
+                </div>
+            @endif
+            @hasSection ('back')
+                <div class="error-button">
+                    <a class="btn is-primary" href="{{ url()->previous() }}">前のページに戻る</a>
+                </div>
+            @endif
+            @if (!empty(config('portal.admin_twitter')))
+                @hasSection ('twitter')
+                    <div class="error-twitter">
+                        <a class="twitter-timeline" data-height="100%" data-chrome="noscrollbar noborders"
+                            href="https://twitter.com/{{ config('portal.admin_twitter') }}?ref_src=twsrc%5Etfw">
+                            Tweets by {{ config('portal.admin_twitter') }}
+                        </a>
+                    </div>
+                @endif
+            @endif
         </div>
-        @endif
-        @endif
-    </div>
-</app-container>
+    </app-container>
 @endsection

--- a/resources/views/errors/layout_no_drawer.blade.php
+++ b/resources/views/errors/layout_no_drawer.blade.php
@@ -1,40 +1,41 @@
 @extends('v2.layouts.no_drawer')
 
 @hasSection ('twitter')
-@push('js')
-    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-@endpush
+    @push('js')
+        <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+    @endpush
 @endif
 
 @section('content')
-<app-container>
-    <div class="error">
-        <div class="error-title">
-            @yield('top')
-        </div>
-        <div class="error-message">
-            @yield('message')
-        </div>
-        @hasSection ('contact')
-            <div class="error-contact">
-                @yield('contact')
-                <p><a href="mailto:{{ config('portal.contact_email') }}">{{ config('portal.contact_email') }}</a></p>
+    <app-container>
+        <div class="error">
+            <div class="error-title">
+                @yield('top')
             </div>
-        @endif
-        @hasSection ('back')
-            <div class="error-button">
-                <button class="btn is-primary" onclick="window.history.back();">前のページに戻る</button>
+            <div class="error-message">
+                @yield('message')
             </div>
-        @endif
-        @if (!empty(config('portal.admin_twitter')))
-        @hasSection ('twitter')
-        <div class="error-twitter">
-            <a class="twitter-timeline" data-height="100%" data-chrome="noscrollbar noborders" href="https://twitter.com/{{ config('portal.admin_twitter') }}?ref_src=twsrc%5Etfw">
-                Tweets by {{ config('portal.admin_twitter') }}
-            </a>
+            @hasSection ('contact')
+                <div class="error-contact">
+                    @yield('contact')
+                    <p><a href="mailto:{{ config('portal.contact_email') }}">{{ config('portal.contact_email') }}</a></p>
+                </div>
+            @endif
+            @hasSection ('back')
+                <div class="error-button">
+                    <a class="btn is-primary" href="{{ url()->previous() }}">前のページに戻る</a>
+                </div>
+            @endif
+            @if (!empty(config('portal.admin_twitter')))
+                @hasSection ('twitter')
+                    <div class="error-twitter">
+                        <a class="twitter-timeline" data-height="100%" data-chrome="noscrollbar noborders"
+                            href="https://twitter.com/{{ config('portal.admin_twitter') }}?ref_src=twsrc%5Etfw">
+                            Tweets by {{ config('portal.admin_twitter') }}
+                        </a>
+                    </div>
+                @endif
+            @endif
         </div>
-        @endif
-        @endif
-    </div>
-</app-container>
+    </app-container>
 @endsection


### PR DESCRIPTION
## 実装内容
close #96 
<!-- どんな実装をしたのか -->
戻るボタンをリンクにし、`url()->previous()` に変更しました

## 懸念点

## レビュワーに見て欲しい点
前いたページに戻れること
エラーページから戻ったあとに正常にフォームを送信できること

## 参考URL
