### PR TITLE
【ユーザー登録】学籍番号入力欄の後ろに @ed.tus.ac.jp などと表示 #107

### DIFF
--- a/resources/js/v2/components/ListViewFormGroup.vue
+++ b/resources/js/v2/components/ListViewFormGroup.vue
@@ -84,3 +84,47 @@ export default {
   }
 }
 </style>
+
+<style lang="scss">
+.form-addon {
+  display: flex;
+  flex-wrap: wrap;
+  &__body {
+    align-items: center;
+    background-color: $color-bg-grey;
+    border: 1px solid $color-border;
+    border-radius: $border-radius;
+    color: $color-muted;
+    display: flex;
+    font-size: $font-size-input;
+    justify-content: center;
+    line-height: 1.6;
+    max-width: 100%;
+    overflow: auto;
+    padding: $spacing-sm $spacing-md;
+    text-align: center;
+    word-break: keep-all;
+    &:first-child {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+      margin-right: -1px;
+    }
+    &:last-child {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+      margin-left: -1px;
+    }
+  }
+  .form-control {
+    flex: 1 1 0%;
+    &:not(:first-child) {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+    }
+    &:not(:last-child) {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+    }
+  }
+}
+</style>

--- a/resources/js/v2/components/ListViewFormGroup.vue
+++ b/resources/js/v2/components/ListViewFormGroup.vue
@@ -16,13 +16,13 @@
     </div>
     <div
       class="listview-form-group__body"
-      :class="{ 'form-append': $slots.prepend || $slots.append }"
+      :class="{ 'form-addon': $slots.prepend || $slots.append }"
     >
-      <div class="form-control form-append__body" v-if="$slots.prepend">
+      <div class="form-control form-addon__body" v-if="$slots.prepend">
         <slot name="prepend" />
       </div>
       <slot />
-      <div class="form-control form-append__body" v-if="$slots.append">
+      <div class="form-control form-addon__body" v-if="$slots.append">
         <slot name="append" />
       </div>
     </div>

--- a/resources/js/v2/components/ListViewFormGroup.vue
+++ b/resources/js/v2/components/ListViewFormGroup.vue
@@ -18,11 +18,11 @@
       class="listview-form-group__body"
       :class="{ 'form-addon': $slots.prepend || $slots.append }"
     >
-      <div class="form-control form-addon__body" v-if="$slots.prepend">
+      <div class="form-addon__body" v-if="$slots.prepend">
         <slot name="prepend" />
       </div>
       <slot />
-      <div class="form-control form-addon__body" v-if="$slots.append">
+      <div class="form-addon__body" v-if="$slots.append">
         <slot name="append" />
       </div>
     </div>

--- a/resources/js/v2/components/ListViewFormGroup.vue
+++ b/resources/js/v2/components/ListViewFormGroup.vue
@@ -14,8 +14,17 @@
     <div class="listview-form-group__description" v-if="$slots.description">
       <slot name="description" />
     </div>
-    <div class="listview-form-group__body">
+    <div
+      class="listview-form-group__body"
+      :class="{ 'form-append': $slots.append_before || $slots.append_after }"
+    >
+      <div class="form-control form-append__body" v-if="$slots.append_before">
+        <slot name="append_before" />
+      </div>
       <slot />
+      <div class="form-control form-append__body" v-if="$slots.append_after">
+        <slot name="append_after" />
+      </div>
     </div>
     <div
       class="listview-form-group__invalid-message"

--- a/resources/js/v2/components/ListViewFormGroup.vue
+++ b/resources/js/v2/components/ListViewFormGroup.vue
@@ -16,14 +16,14 @@
     </div>
     <div
       class="listview-form-group__body"
-      :class="{ 'form-append': $slots.append_before || $slots.append_after }"
+      :class="{ 'form-append': $slots.prepend || $slots.append }"
     >
-      <div class="form-control form-append__body" v-if="$slots.append_before">
-        <slot name="append_before" />
+      <div class="form-control form-append__body" v-if="$slots.prepend">
+        <slot name="prepend" />
       </div>
       <slot />
-      <div class="form-control form-append__body" v-if="$slots.append_after">
-        <slot name="append_after" />
+      <div class="form-control form-append__body" v-if="$slots.append">
+        <slot name="append" />
       </div>
     </div>
     <div

--- a/resources/sass/v2/modules/_forms.scss
+++ b/resources/sass/v2/modules/_forms.scss
@@ -86,45 +86,4 @@ textarea {
     display: block;
     margin: $spacing-xs 0;
   }
-  &-addon {
-    display: flex;
-    flex-wrap: wrap;
-    &__body {
-      align-items: center;
-      background-color: $color-bg-grey;
-      border: 1px solid $color-border;
-      border-radius: $border-radius;
-      color: $color-muted;
-      display: flex;
-      font-size: $font-size-input;
-      justify-content: center;
-      line-height: 1.6;
-      max-width: 100%;
-      overflow: auto;
-      padding: $spacing-sm $spacing-md;
-      text-align: center;
-      word-break: keep-all;
-      &:first-child {
-        border-bottom-right-radius: 0;
-        border-top-right-radius: 0;
-        margin-right: -1px;
-      }
-      &:last-child {
-        border-bottom-left-radius: 0;
-        border-top-left-radius: 0;
-        margin-left: -1px;
-      }
-    }
-    .form-control {
-      flex: 1 1 0%;
-      &:not(:first-child) {
-        border-bottom-left-radius: 0;
-        border-top-left-radius: 0;
-      }
-      &:not(:last-child) {
-        border-bottom-right-radius: 0;
-        border-top-right-radius: 0;
-      }
-    }
-  }
 }

--- a/resources/sass/v2/modules/_forms.scss
+++ b/resources/sass/v2/modules/_forms.scss
@@ -86,7 +86,7 @@ textarea {
     display: block;
     margin: $spacing-xs 0;
   }
-  &-append {
+  &-addon {
     display: flex;
     &__body {
       background: $color-bg-grey;

--- a/resources/sass/v2/modules/_forms.scss
+++ b/resources/sass/v2/modules/_forms.scss
@@ -86,4 +86,26 @@ textarea {
     display: block;
     margin: $spacing-xs 0;
   }
+  &-append {
+    display: flex;
+    &__body {
+      background: $color-bg-grey;
+      color: $color-muted;
+      white-space: nowrap;
+      width: auto;
+    }
+    .form-control {
+      border-radius: 0;
+      border-right: none;
+      &:first-child {
+        border-bottom-left-radius: 0.25rem;
+        border-top-left-radius: 0.25rem;
+      }
+      &:last-child {
+        border-bottom-right-radius: 0.25rem;
+        border-right: 1px solid $color-border;
+        border-top-right-radius: 0.25rem;
+      }
+    }
+  }
 }

--- a/resources/sass/v2/modules/_forms.scss
+++ b/resources/sass/v2/modules/_forms.scss
@@ -91,8 +91,8 @@ textarea {
     &__body {
       background: $color-bg-grey;
       color: $color-muted;
-      white-space: nowrap;
       width: auto;
+      word-break: keep-all;
     }
     .form-control {
       border-radius: 0;

--- a/resources/sass/v2/modules/_forms.scss
+++ b/resources/sass/v2/modules/_forms.scss
@@ -88,23 +88,42 @@ textarea {
   }
   &-addon {
     display: flex;
+    flex-wrap: wrap;
     &__body {
-      background: $color-bg-grey;
+      align-items: center;
+      background-color: $color-bg-grey;
+      border: 1px solid $color-border;
+      border-radius: $border-radius;
       color: $color-muted;
-      width: auto;
+      display: flex;
+      font-size: $font-size-input;
+      justify-content: center;
+      line-height: 1.6;
+      max-width: 100%;
+      overflow: auto;
+      padding: $spacing-sm $spacing-md;
+      text-align: center;
       word-break: keep-all;
-    }
-    .form-control {
-      border-radius: 0;
-      border-right: none;
       &:first-child {
-        border-bottom-left-radius: 0.25rem;
-        border-top-left-radius: 0.25rem;
+        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
+        margin-right: -1px;
       }
       &:last-child {
-        border-bottom-right-radius: 0.25rem;
-        border-right: 1px solid $color-border;
-        border-top-right-radius: 0.25rem;
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
+        margin-left: -1px;
+      }
+    }
+    .form-control {
+      flex: 1 1 0%;
+      &:not(:first-child) {
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
+      }
+      &:not(:last-child) {
+        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
       }
     }
   }

--- a/resources/views/v2/users/edit.blade.php
+++ b/resources/views/v2/users/edit.blade.php
@@ -25,7 +25,7 @@
                     @error('student_id')
                     <template v-slot:invalid>{{ $message }}</template>
                     @enderror
-                    <template v-slot:append_after>
+                    <template v-slot:append>
                         {{ '@' . config('portal.univemail_domain') }}
                     </template>
                 </list-view-form-group>

--- a/resources/views/v2/users/edit.blade.php
+++ b/resources/views/v2/users/edit.blade.php
@@ -25,6 +25,9 @@
                     @error('student_id')
                     <template v-slot:invalid>{{ $message }}</template>
                     @enderror
+                    <template v-slot:append_after>
+                        {{ '@' . config('portal.univemail_domain') }}
+                    </template>
                 </list-view-form-group>
                 <list-view-form-group label-for="name">
                     <template v-slot:label>名前</template>

--- a/resources/views/v2/users/register.blade.php
+++ b/resources/views/v2/users/register.blade.php
@@ -19,6 +19,9 @@
                     @error('student_id')
                     <template v-slot:invalid>{{ $message }}</template>
                     @enderror
+                    <template v-slot:append_after>
+                        {{ '@' . config('portal.univemail_domain') }}
+                    </template>
                 </list-view-form-group>
                 <list-view-form-group label-for="name">
                     <template v-slot:label>名前</template>

--- a/resources/views/v2/users/register.blade.php
+++ b/resources/views/v2/users/register.blade.php
@@ -19,7 +19,7 @@
                     @error('student_id')
                     <template v-slot:invalid>{{ $message }}</template>
                     @enderror
-                    <template v-slot:append_after>
+                    <template v-slot:append>
                         {{ '@' . config('portal.univemail_domain') }}
                     </template>
                 </list-view-form-group>


### PR DESCRIPTION
## 実装内容
close #107 
<!-- どんな実装をしたのか -->
LietViewFormGroupに `prepend` と `append` という slot を作成しました
それぞれ前後に文字などを表示させることができます

## 懸念点
![image](https://user-images.githubusercontent.com/8391342/82141972-eb073300-9873-11ea-9a07-6ac3a96eb9c6.png)
長い文字列を入れると大変なことになる

## レビュワーに見て欲しい点
- スタイルの記述などで変なところがないか

## 参考URL
