### PR TITLE
【アカウント削除】スタッフor管理者の場合はアカウントを削除できないようにする #93

### DIFF
--- a/app/Http/Controllers/Users/DeleteAction.php
+++ b/app/Http/Controllers/Users/DeleteAction.php
@@ -15,6 +15,7 @@ class DeleteAction extends Controller
 
         return view('v2.users.delete')
             ->with('is_admin', $user->is_admin)
+            ->with('is_staff', $user->is_staff)
             ->with('belong', !$circles->isEmpty());
     }
 }

--- a/app/Http/Controllers/Users/DestroyAction.php
+++ b/app/Http/Controllers/Users/DestroyAction.php
@@ -15,10 +15,10 @@ class DestroyAction extends Controller
 
         $circles = $user->circles;
 
-        if ($user->is_admin) {
+        if ($user->is_admin || $user->is_staff) {
             return redirect()
                 ->route('user.delete')
-                ->with('topAlert.title', '管理者ユーザーの削除はできません。');
+                ->with('topAlert.title', '管理者ユーザー・スタッフの削除はできません。');
         }
 
         if (!$circles->isEmpty()) {

--- a/resources/views/v2/users/delete.blade.php
+++ b/resources/views/v2/users/delete.blade.php
@@ -8,8 +8,8 @@
         <list-view>
             <template v-slot:title>アカウント削除</template>
             <list-view-card class="text-center">
-                @if ($is_admin)
-                    <p class="card-text">管理者ユーザーはアカウント削除できません。</p>
+                @if ($is_admin || $is_staff)
+                    <p class="card-text">管理者ユーザー・スタッフはアカウント削除できません。</p>
                     <div>
                         <a href="{{ route('home') }}" class="btn is-primary">ホームに戻る</a>
                     </div>

--- a/tests/Feature/Http/Controllers/Users/DestroyActionTest.php
+++ b/tests/Feature/Http/Controllers/Users/DestroyActionTest.php
@@ -66,6 +66,28 @@ class DestroyActionTest extends TestCase
     /**
      * @test
      */
+    public function スタッフユーザーは削除できない()
+    {
+        $this->user->is_staff = true;
+        $this->user->save();
+
+        $this->assertDatabaseHas('users', [
+            'id' => $this->user->id,
+            'is_staff' => 1,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->delete(route('user.destroy'));
+
+        $this->assertDatabaseHas('users', [
+            'id' => $this->user->id,
+            'is_staff' => 1,
+        ]);
+    }
+
+    /**
+     * @test
+     */
     public function 企画に所属しているユーザーは削除できない()
     {
         $circle = factory(Circle::class)->create();


### PR DESCRIPTION
## 実装内容
close #93
<!-- どんな実装をしたのか -->

- スタッフはユーザー削除できないようにしました
    - 管理者アカウントは、 #83 実装時に削除不可にしていた

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
