### PR TITLE
LaravelとCodeIgniterのルーティング切り替えを、CodeIgniterのルーティングを羅列する方式にする #91

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -60,8 +60,6 @@ if (!defined('PORTAL_UPLOAD_DIR')) {
 // PORTAL_UPLOAD_DIR と似た設定ですが、設定方法が異なります。
 // 先頭にスラッシュ(/)をつけることは で き ま せ ん。
 // public/index.php からみたディレクトリを指定してください。
-// ただし、さくらのレンタルサーバーにデプロイする場合、sakura_deploy.sh ファイルに
-// 記載されている PORTAL_UPLOAD_DIR_CRUD についての指示に従ってください
 if (!defined('PORTAL_UPLOAD_DIR_CRUD')) {
     define('PORTAL_UPLOAD_DIR_CRUD', codeigniter_env('PORTAL_UPLOAD_DIR_CRUD', '../application/uploads'));
 }

--- a/application/controllers/Home_staff.php
+++ b/application/controllers/Home_staff.php
@@ -1306,7 +1306,7 @@ class Home_staff extends MY_Controller
             );
         } else {
             // POST のとき
-            $code_on_session = $_SESSION["staff_verify_code"];
+            $code_on_session = isset($_SESSION["staff_verify_code"]) ? $_SESSION["staff_verify_code"] : null;
             unset($_SESSION["staff_verify_code"]);
 
             if (isset($code_on_session) &&

--- a/application/views/layouts/layout_main.html.twig
+++ b/application/views/layouts/layout_main.html.twig
@@ -28,7 +28,7 @@
         </p>
         {% if user.is_staff == 1 %}
         <p>
-          {% if _home_type == "staff" %}<a href="{{ base_url('home') }}" class="btn btn-default btn-block">一般モードへ</a>{% endif %}
+          {% if _home_type == "staff" %}<a href="{{ base_url('/') }}" class="btn btn-default btn-block">一般モードへ</a>{% endif %}
           {% if _home_type == "default" %}<a href="{{ base_url('home_staff') }}" class="btn btn-default btn-block">スタッフモードへ</a>{% endif %}
         </p>
         {% endif %}

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -15,6 +15,12 @@
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
+    # URLの末尾にスラッシュをつけてアクセスすると、publicディレクトリ内へ
+    # リダイレクトしてしまうことがあるので、それを防ぐ
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteCond %{REQUEST_URI} public/(.+)/$
+    RewriteRule ^ %1 [L,R=301]
+
     # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_URI} (.+)/$

--- a/public/index.php
+++ b/public/index.php
@@ -40,56 +40,25 @@ require_once(__DIR__. '/../vendor/autoload.php');
 
 use Symfony\Component\HttpFoundation\IpUtils;
 
-// 一部 Laravel にルーティング
+// ほとんどのページは Laravel にルーティング
+// スタッフモード等、一部のページのみ CodeIgniter へルーティング
 (function () {
-    // 以下の配列にあげたパスの他、
-    // Laravel 側でメンテナンスモードが有効になっている場合も、
-    // Laravel にルーティングされる
-    $LARAVEL_PATHS = [
-        // Home
-        '/pages',
-        '/documents',
-        '/schedules',
-        '/forms',
-        // Auth
-        '/login',
-        '/logout',
-        '/register',
-        '/password',
-        '/email',
-        // Users
-        '/user',
-        '/contacts',
-        '/selector',
-        // Circles
-        '/circles',
-        // Staff
-        '/staff',
-        '/admin',
-        // Debugbar
-        '/_debugbar',
-        // インストーラー
-        '/install',
-    ];
+    $request_uri = $_SERVER['REQUEST_URI'];
 
+    // メンテナンス中表示をするか判定
+    $is_maintenance = false;
     if (file_exists($down_path = __DIR__. '/../storage/framework/down')) {
         $data = json_decode(file_get_contents($down_path), true);
 
         if (!isset($data['allowed']) || !IpUtils::checkIp($_SERVER['REMOTE_ADDR'], (array) $data['allowed'])) {
             // メンテナンスモードが有効の場合、かつ許可 IP アドレスからのアクセスではない場合、Laravel へルーティング
-            require __DIR__. '/index_laravel.php';
-            exit;
+            $is_maintenance = true;
         }
     }
 
-    $request_uri = $_SERVER['REQUEST_URI'];
-
-    foreach ($LARAVEL_PATHS as $path) {
-        $path = str_replace('/', '\/', preg_quote($path));
-        if ($request_uri === '/' || preg_match('/^'. $path. '/', $request_uri)) {
-            require __DIR__. '/index_laravel.php';
-            exit;
-        }
+    if (!preg_match('/^\/home_staff/', $request_uri) || $is_maintenance) {
+        require __DIR__. '/index_laravel.php';
+        exit;
     }
 })();
 


### PR DESCRIPTION
## 実装内容
close #91
<!-- どんな実装をしたのか -->

- index.php に Laravel の URL を羅列するのをやめ、CodeIgniter へルーティングするかどうかだけの処理にしました

## 懸念点

## レビュワーに見て欲しい点
- 正常にアクセスできなくなってしまったページがないかどうか

## 参考URL
