### PR TITLE
【DownloadZipServiceTest】use RefreshDatabaseのコメントアウトを解除 #126

### DIFF
--- a/app/Http/Controllers/Staff/Forms/CopyAction.php
+++ b/app/Http/Controllers/Staff/Forms/CopyAction.php
@@ -19,7 +19,7 @@ class CopyAction extends Controller
 
     public function __invoke(Form $form)
     {
-        $form_copy = $this->formsService->copyForm($form);
+        $form_copy = $this->formsService->copyForm($form, Auth::user());
 
         return redirect("/home_staff/applications/read/{$form_copy->id}?copied=1");
     }

--- a/app/Services/Forms/FormsService.php
+++ b/app/Services/Forms/FormsService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Forms;
 
 use App\Eloquents\Form;
+use App\Eloquents\User;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -30,14 +31,15 @@ class FormsService
      * フォームを複製する
      *
      * @param Form $form
+     * @param User $user フォームの作成者とするユーザー
      * @return Form|null
      */
-    public function copyForm(Form $form)
+    public function copyForm(Form $form, User $user)
     {
-        return DB::transaction(function () use ($form) {
+        return DB::transaction(function () use ($form, $user) {
             $form_copy = $form->replicate()->fill([
                 'name' => $form->name . 'のコピー',
-                'created_by' => Auth::id(),
+                'created_by' => $user->id,
                 'is_public' => false,
             ]);
 

--- a/tests/Feature/Http/Controllers/Auth/LoginControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/LoginControllerTest.php
@@ -8,6 +8,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class LoginControllerTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * @test
      */

--- a/tests/Feature/Http/Controllers/Forms/Answers/Uploads/ShowActionTest.php
+++ b/tests/Feature/Http/Controllers/Forms/Answers/Uploads/ShowActionTest.php
@@ -8,6 +8,8 @@ use Tests\TestCase;
 
 class ShowActionTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * @test
      */

--- a/tests/Feature/Http/Controllers/Install/HomeActionTest.php
+++ b/tests/Feature/Http/Controllers/Install/HomeActionTest.php
@@ -9,6 +9,8 @@ use Jackiedo\DotenvEditor\DotenvEditor;
 
 class HomeActionTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * @test
      */

--- a/tests/Feature/Http/Controllers/Staff/Forms/CopyActionTest.php
+++ b/tests/Feature/Http/Controllers/Staff/Forms/CopyActionTest.php
@@ -29,7 +29,9 @@ class CopyActionTest extends TestCase
     {
         $this->mock(FormsService::class, function ($mock) {
             $mock->shouldReceive('copyForm')->once()->with(Mockery::on(function ($arg) {
-                return $this->form->id === $arg->id;
+                return $this->form->id === $arg->id && $this->form->name === $arg->name;
+            }), Mockery::on(function ($arg) {
+                return $this->staff->id === $arg->id && $this->staff->name === $arg->name;
             }))->andReturn($this->form_copy);
         });
 

--- a/tests/Feature/Services/Forms/DownloadZipServiceTest.php
+++ b/tests/Feature/Services/Forms/DownloadZipServiceTest.php
@@ -20,7 +20,7 @@ use App\Services\Forms\Exceptions\ZipArchiveNotSupportedException;
 
 class DownloadZipServiceTest extends TestCase
 {
-    // use RefreshDatabase;
+    use RefreshDatabase;
 
     private $form;
     private $answer;

--- a/tests/Feature/Services/Forms/FormsServiceTest.php
+++ b/tests/Feature/Services/Forms/FormsServiceTest.php
@@ -19,7 +19,7 @@ class FormsServiceTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->FormService = App::make(FormsService::class);
+        $this->formsService = App::make(FormsService::class);
         $this->user = factory(User::class)->create();
         $this->form = factory(Form::class)->create([
             'name' => 'テスト申請',
@@ -35,7 +35,7 @@ class FormsServiceTest extends TestCase
      */
     public function copyForm_申請の複製ができる()
     {
-        $form = $this->actingAs($this->user)->FormService->copyForm($this->form);
+        $form = $this->formsService->copyForm($this->form, $this->user);
 
         $this->assertInstanceOf(Form::class, $form);
 


### PR DESCRIPTION
## 実装内容
close #126
<!-- どんな実装をしたのか -->

- なぜかuse RefreshDatabaseがコメントアウトされていた箇所をコメントアウト解除
- use RefreshDatabase が無いコードに use RefreshDatabase を追加
- コードの変更に強くするため、copyForm関数実行時にはコピー実行者ユーザーも引数として渡す
    - 関数内のパラメータはぜんぶ引数で渡したほうが、copyForm関数を実行する側のコードが読みやすくなるので。
        - `$this->formsService->copyForm($hoge)` としか書かれていないと、「copyForm はログインしている前提ではないと動作しない」ということが読み取れない

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
