### PR TITLE
【開発環境】localhost外からでもスタッフモードにアクセスできるようにする #143

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -128,7 +128,11 @@ if (!defined('MAIL_PORT')) {
 | a PHP script and you can easily do that on your own.
 |
 */
-$config['base_url'] = codeigniter_env('APP_URL', 'http://localhost/');
+if (ENVIRONMENT === 'development') {
+    $config['base_url'] = '/';
+} else {
+    $config['base_url'] = codeigniter_env('APP_URL', 'http://localhost/');
+}
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## 実装内容
close #143
<!-- どんな実装をしたのか -->

開発環境が起動している PC と同じネットワーク内のコンピューター（スマホなど）からでも、スタッフモードにアクセスできるようにしました。

## 懸念点

## レビュワーに見て欲しい点

yarn watch 起動時に出てくる以下の「External」の URL にアクセスしたときでも、スタッフモードにアクセスすることができるか。

![image](https://user-images.githubusercontent.com/6687653/83962115-58d3d700-a8d5-11ea-9932-0c33d0f72ef4.png)

## 参考URL
