### PR TITLE
【企画参加登録•申請】メール未認証時、なぜ申請できないのかをわかりやすく #81

### DIFF
--- a/app/Policies/Circle/CreatePolicy.php
+++ b/app/Policies/Circle/CreatePolicy.php
@@ -21,7 +21,7 @@ class CreatePolicy
     {
     }
 
-    public function __invoke(User $user)
+    public function __invoke(?User $user)
     {
         $custom_form = CustomForm::getFormByType('circle');
         return isset($custom_form)

--- a/resources/views/v2/home.blade.php
+++ b/resources/views/v2/home.blade.php
@@ -96,13 +96,33 @@
         </header>
     @endguest
     <app-container>
-        @if (Auth::check() && Auth::user()->areBothEmailsVerified() && Auth::user()->can('circle.create'))
+        @if (Gate::allows('circle.create'))
             <list-view>
                 <template v-slot:title>企画参加登録</template>
                 <template v-slot:description>
                     受付期間 : @datetime($circle_custom_form->open_at)〜@datetime($circle_custom_form->close_at)
                 </template>
-                @if (count($my_circles) === 0)
+                @if (!Auth::check())
+                    <list-view-card>
+                        <list-view-empty text="企画参加登録するには、まずログインしてください">
+                            <p>
+                                {{ config('app.name') }}の利用がはじめての場合は<a href="{{ route('register') }}">ユーザー登録</a>を行ってください。<br>
+                                <a href="{{ route('login') }}">ログインはこちら</a>
+                            </p>
+                        </list-view-empty>
+                    </list-view-card>
+                @elseif (!Auth::user()->areBothEmailsVerified())
+                    <list-view-card>
+                        <list-view-empty icon-class="far fa-envelope" text="メール認証が未完了です">
+                            <p>
+                                参加登録を行うには、まずメール認証を完了させてください。
+                            </p>
+                            <a href="{{ route('verification.notice') }}" class="btn is-primary is-wide">
+                                <strong>もっと詳しく</strong>
+                            </a>
+                        </list-view-empty>
+                    </list-view-card>
+                @elseif (count($my_circles) === 0)
                     <list-view-card>
                         <list-view-empty icon-class="far fa-star" text="参加登録をしましょう！">
                             <p>
@@ -110,7 +130,7 @@
                                 まずは参加登録からはじめましょう！
                             </p>
                             <a href="{{ route('circles.create') }}" class="btn is-primary is-wide">
-                                参加登録をはじめる
+                                <strong>参加登録をはじめる</strong>
                             </a>
                         </list-view-empty>
                     </list-view-card>
@@ -269,7 +289,7 @@
             </list-view>
         @endif
 
-        @if (!$forms->isEmpty())
+        @if (!$forms->isEmpty() && Auth::user()->circles()->approved()->count() > 0)
             <list-view>
                 <template v-slot:title>受付中の申請</template>
                 @foreach ($forms as $form)

--- a/resources/views/v2/home.blade.php
+++ b/resources/views/v2/home.blade.php
@@ -289,7 +289,7 @@
             </list-view>
         @endif
 
-        @if (!$forms->isEmpty() && Auth::user()->circles()->approved()->count() > 0)
+        @if (!$forms->isEmpty() && Auth::check() && Auth::user()->circles()->approved()->count() > 0)
             <list-view>
                 <template v-slot:title>受付中の申請</template>
                 @foreach ($forms as $form)

--- a/tests/Feature/Http/Controllers/HomeActionTest.php
+++ b/tests/Feature/Http/Controllers/HomeActionTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Carbon\CarbonImmutable;
 use Jackiedo\DotenvEditor\DotenvEditor;
 use App\Eloquents\User;
+use App\Eloquents\Circle;
 use App\Eloquents\Form;
 use App\Eloquents\CustomForm;
 
@@ -98,7 +99,10 @@ class HomeActionTest extends TestCase
             'name' => $normalFormName
         ]);
 
-        $response = $this->get(route('home'));
+        $circle = factory(Circle::class)->create();
+        $user = factory(User::class)->create();
+        $user->circles()->attach($circle, ['is_leader' => true]);
+        $response = $this->actingAs($user)->get(route('home'));
 
         $response->assertDontSee($customFormName);
         $response->assertSee($normalFormName);


### PR DESCRIPTION
## 実装内容
close #81
<!-- どんな実装をしたのか -->

- ユーザー登録未完了 or メール認証未完了のときは参加登録できないことを表示するようにしました
- 未ログイン時 or 参加登録が受理されていない場合、ホーム画面に申請一覧を表示しないようにしました

![image](https://user-images.githubusercontent.com/6687653/84244983-5d9bc380-ab3f-11ea-88d8-1408ffa81aad.png)

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
