### PR TITLE
【企画参加登録】参加登録を削除できるようにする #113

### DIFF
--- a/app/Eloquents/CircleUser.php
+++ b/app/Eloquents/CircleUser.php
@@ -9,4 +9,8 @@ use App\Eloquents\User;
 class CircleUser extends Pivot
 {
     public $incrementing = true;
+
+    protected $casts = [
+        'is_leader' => 'bool',
+    ];
 }

--- a/app/Http/Controllers/Circles/DeleteAction.php
+++ b/app/Http/Controllers/Circles/DeleteAction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Circles;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use App\Eloquents\Circle;
+
+class DeleteAction extends Controller
+{
+    public function __invoke(Circle $circle)
+    {
+        $this->authorize('circle.update', $circle);
+
+        $user = $circle->users()->wherePivot('user_id', Auth::id())->first();
+
+        if (empty($user) || !$user->pivot->is_leader) {
+            // リーダー以外は参加登録の削除はできない
+            abort(403);
+        }
+
+        return view('v2.circles.delete')
+            ->with('circle', $circle);
+    }
+}

--- a/app/Http/Controllers/Circles/DestroyAction.php
+++ b/app/Http/Controllers/Circles/DestroyAction.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Circles;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use App\Eloquents\Circle;
+
+class DestroyAction extends Controller
+{
+    public function __invoke(Circle $circle)
+    {
+        $this->authorize('circle.update', $circle);
+
+        $user = $circle->users()->wherePivot('user_id', Auth::id())->first();
+
+        if (empty($user) || !$user->pivot->is_leader) {
+            // リーダー以外は参加登録の削除はできない
+            abort(403);
+        }
+
+        return DB::transaction(function () use ($circle) {
+            $circle->users()->detach();
+            $circle->answers()->delete();
+            $circle->delete();
+
+            return redirect()
+                ->route('home')
+                ->with('topAlert.title', '企画参加登録を削除しました');
+        });
+    }
+}

--- a/resources/views/v2/circles/delete.blade.php
+++ b/resources/views/v2/circles/delete.blade.php
@@ -1,0 +1,32 @@
+@extends('v2.layouts.no_drawer')
+
+@section('title', '企画参加登録')
+
+@section('content')
+    <app-header container-medium>
+        <template v-slot:title>
+            企画参加登録
+        </template>
+    </app-header>
+
+    <app-container medium>
+        <list-view>
+            <template v-slot:title>参加登録の削除</template>
+            <list-view-card class="text-center">
+                <p>「{{ $circle->name }}」({{ $circle->group_name }})の企画参加登録を削除します。</p>
+
+                <form-with-confirm action="{{ route('circles.destroy', ['circle' => $circle]) }}" method="post"
+                    confirm-message="本当に「{{ $circle->name }}」({{ $circle->group_name }})の企画参加登録を削除しますか？">
+                    @method('delete')
+                    @csrf
+                    <button type="submit" class="btn is-danger">
+                        <strong>参加登録を削除</strong>
+                    </button>
+                    <a href="{{ url()->previous() }}" class="btn is-secondary">
+                        削除しない
+                    </a>
+                </form-with-confirm>
+            </list-view-card>
+        </list-view>
+    </app-container>
+@endsection

--- a/resources/views/v2/includes/circle_register_header.blade.php
+++ b/resources/views/v2/includes/circle_register_header.blade.php
@@ -17,6 +17,15 @@ $step = 3;
     @isset ($circle)
         <p class="text-muted">
             {{ $circle->name }}
+
+            @php
+            $this_user = $circle->users()->wherePivot('user_id', Auth::id())->first();
+            @endphp
+
+            @if (!empty($this_user) && $this_user->pivot->is_leader)
+                —
+                <a href="{{ route('circles.delete', ['circle' => $circle]) }}">この参加登録を削除</a>
+            @endif
         </p>
     @endisset
     <steps-list>

--- a/routes/web.php
+++ b/routes/web.php
@@ -108,6 +108,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
             // 参加登録の提出
             Route::get('/{circle}/confirm', 'Circles\ConfirmAction')->name('confirm');
             Route::post('/{circle}/submit', 'Circles\SubmitAction')->name('submit');
+            // 参加登録の削除
+            Route::get('/{circle}/delete', 'Circles\DeleteAction')->name('delete');
+            Route::delete('/{circle}', 'Circles\DestroyAction')->name('destroy');
             // 参加登録状況
             Route::get('/{circle}/status', 'Circles\StatusAction')->name('status');
         });

--- a/tests/Feature/Http/Controllers/Circles/DeleteActionTest.php
+++ b/tests/Feature/Http/Controllers/Circles/DeleteActionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Circles;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use App\Eloquents\User;
+use App\Eloquents\Circle;
+use App\Eloquents\Form;
+use App\Eloquents\CustomForm;
+use App\Eloquents\Answer;
+
+class DeleteActionTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    private $user;
+    private $circle;
+    private $answer;
+    private $nonLeader;
+    private $anotherUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+        $this->circle = factory(Circle::class)->states('notSubmitted')->create();
+        $this->answer = factory(Answer::class)->create([
+            'form_id' => $this->form->id,
+            'circle_id' => $this->circle->id,
+        ]);
+
+        $this->user->circles()->attach($this->circle->id, ['is_leader' => true]);
+
+        // 受付期間内
+        Carbon::setTestNow(new CarbonImmutable('2020-02-16 02:25:15'));
+        CarbonImmutable::setTestNow(new CarbonImmutable('2020-02-16 02:25:15'));
+
+        // メンバー
+        $this->nonLeader = factory(User::class)->create();
+        $this->nonLeader->circles()->attach($this->circle->id, ['is_leader' => false]);
+
+        // メンバーではない
+        $this->anotherUser = factory(User::class)->create();
+    }
+
+    /**
+     * @test
+     */
+    public function 参加登録未提出であればアクセスできる()
+    {
+        $response = $this->actingAs($this->user)
+            ->get(
+                route('circles.delete', [
+                    'circle' => $this->circle,
+                ])
+            );
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * @test
+     */
+    public function リーダー以外のメンバーはアクセスできない()
+    {
+        $response = $this->actingAs($this->nonLeader)
+            ->get(
+                route('circles.delete', [
+                    'circle' => $this->circle,
+                ])
+            );
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * @test
+     */
+    public function 部外者はアクセスできない()
+    {
+        $response = $this->actingAs($this->anotherUser)
+            ->get(
+                route('circles.delete', [
+                    'circle' => $this->circle,
+                ])
+            );
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * @test
+     */
+    public function 提出済みの企画は削除できない()
+    {
+        $this->circle->submitted_at = now();
+        $this->circle->save();
+
+        $response = $this->actingAs($this->user)
+            ->get(
+                route('circles.delete', [
+                    'circle' => $this->circle,
+                ])
+            );
+
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Feature/Http/Controllers/Circles/DestroyActionTest.php
+++ b/tests/Feature/Http/Controllers/Circles/DestroyActionTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Circles;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use App\Eloquents\User;
+use App\Eloquents\Circle;
+use App\Eloquents\Form;
+use App\Eloquents\CustomForm;
+use App\Eloquents\Answer;
+
+class DestroyActionTest extends BaseTestCase
+{
+    use RefreshDatabase;
+
+    private $user;
+    private $circle;
+    private $answer;
+    private $nonLeader;
+    private $anotherUser;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+        $this->circle = factory(Circle::class)->states('notSubmitted')->create();
+        $this->answer = factory(Answer::class)->create([
+            'form_id' => $this->form->id,
+            'circle_id' => $this->circle->id,
+        ]);
+
+        $this->user->circles()->attach($this->circle->id, ['is_leader' => true]);
+
+        // 受付期間内
+        Carbon::setTestNow(new CarbonImmutable('2020-02-16 02:25:15'));
+        CarbonImmutable::setTestNow(new CarbonImmutable('2020-02-16 02:25:15'));
+
+        // メンバー
+        $this->nonLeader = factory(User::class)->create();
+        $this->nonLeader->circles()->attach($this->circle->id, ['is_leader' => false]);
+
+        // メンバーではない
+        $this->anotherUser = factory(User::class)->create();
+    }
+
+    /**
+     * @test
+     */
+    public function 参加登録未提出の企画を削除できる()
+    {
+        $this->assertDatabaseHas('circles', [
+            'id' => $this->circle->id,
+        ]);
+
+        $this->assertDatabaseHas('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->assertDatabaseHas('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->nonLeader->id,
+        ]);
+
+        $this->assertDatabaseHas('answers', [
+            'form_id' => $this->form->id,
+            'circle_id' => $this->circle->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->delete(
+                route('circles.destroy', [
+                    'circle' => $this->circle,
+                ])
+            );
+
+        $this->assertDatabaseMissing('circles', [
+            'id' => $this->circle->id,
+        ]);
+
+        $this->assertDatabaseMissing('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->assertDatabaseMissing('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->nonLeader->id,
+        ]);
+
+        $this->assertDatabaseMissing('answers', [
+            'form_id' => $this->form->id,
+            'circle_id' => $this->circle->id,
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertRedirect(route('home'));
+    }
+
+    /**
+     * @test
+     */
+    public function リーダー以外のメンバーは企画を削除できない()
+    {
+        $response = $this->actingAs($this->nonLeader)
+            ->delete(
+                route('circles.destroy', [
+                    'circle' => $this->circle,
+                ])
+            );
+
+        $this->assertDatabaseHas('circles', [
+            'id' => $this->circle->id,
+        ]);
+
+        $this->assertDatabaseHas('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->assertDatabaseHas('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->nonLeader->id,
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * @test
+     */
+    public function 部外者は企画を削除できない()
+    {
+        $response = $this->actingAs($this->anotherUser)
+            ->delete(
+                route('circles.destroy', [
+                    'circle' => $this->circle,
+                ])
+            );
+
+        $this->assertDatabaseHas('circles', [
+            'id' => $this->circle->id,
+        ]);
+
+        $this->assertDatabaseHas('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->assertDatabaseHas('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->nonLeader->id,
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    /**
+     * @test
+     */
+    public function 提出済みの企画は削除できない()
+    {
+        $this->circle->submitted_at = now();
+        $this->circle->save();
+
+        $response = $this->actingAs($this->user)
+            ->delete(
+                route('circles.destroy', [
+                    'circle' => $this->circle,
+                ])
+            );
+
+        $this->assertDatabaseHas('circles', [
+            'id' => $this->circle->id,
+        ]);
+
+        $this->assertDatabaseHas('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->assertDatabaseHas('circle_user', [
+            'circle_id' => $this->circle->id,
+            'user_id' => $this->nonLeader->id,
+        ]);
+
+        $response->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## 実装内容
close #113
<!-- どんな実装をしたのか -->

参加登録提出前、かつ企画責任者であれば、参加登録を削除できるようにしました。

![image](https://user-images.githubusercontent.com/6687653/84407087-55c64700-ac45-11ea-9651-753fc6c363e0.png)

![image](https://user-images.githubusercontent.com/6687653/84407143-62e33600-ac45-11ea-94f6-89f06d9ccf62.png)

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
