### PR TITLE
【メール認証】メール認証画面では企画セレクタを表示しない #193

### DIFF
--- a/resources/views/v2/auth/passwords/request.blade.php
+++ b/resources/views/v2/auth/passwords/request.blade.php
@@ -1,11 +1,13 @@
 @extends('v2.layouts.no_drawer')
 
+@section('no_circle_selector', true)
+
 @section('title', 'パスワードの再設定')
-    
+
 @section('content')
     <form method="POST">
         @csrf
-    
+
         <app-container medium>
             <list-view>
                 <template v-slot:title>パスワードの再設定</template>

--- a/resources/views/v2/auth/passwords/reset.blade.php
+++ b/resources/views/v2/auth/passwords/reset.blade.php
@@ -1,11 +1,13 @@
 @extends('v2.layouts.no_drawer')
 
+@section('no_circle_selector', true)
+
 @section('title', 'パスワードの再設定')
-    
+
 @section('content')
     <form method="POST" action="{{ url()->full() }}">
         @csrf
-    
+
         <app-container medium>
             <list-view>
                 <template v-slot:title>パスワードの再設定</template>

--- a/resources/views/v2/auth/verify.blade.php
+++ b/resources/views/v2/auth/verify.blade.php
@@ -1,5 +1,7 @@
 @extends('v2.layouts.no_drawer')
 
+@section('no_circle_selector', true)
+
 @section('title', 'メール認証のお願い')
 
 @section('content')

--- a/resources/views/v2/auth/verify_completed.blade.php
+++ b/resources/views/v2/auth/verify_completed.blade.php
@@ -1,5 +1,7 @@
 @extends('v2.layouts.no_drawer')
 
+@section('no_circle_selector', true)
+
 @section('title', 'メール認証完了')
 
 @section('content')


### PR DESCRIPTION
## 実装内容
close #193
<!-- どんな実装をしたのか -->

メール認証ページなど、企画セレクタを表示する必要のないページでは企画セレクタを非表示にしました。

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
