### PR TITLE
サーバーがQRコード生成に対応していない場合、500エラーにならないように

### DIFF
--- a/app/Http/Controllers/Circles/Users/IndexAction.php
+++ b/app/Http/Controllers/Circles/Users/IndexAction.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Circles\Users;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Eloquents\Circle;
+use QrCode;
+use BaconQrCode\Exception\RuntimeException;
 
 class IndexAction extends Controller
 {
@@ -21,9 +23,24 @@ class IndexAction extends Controller
             'token' => $circle->invitation_token
         ]);
 
+        $invitation_url_for_blade = str_replace('"', '', \json_encode($invitation_url, JSON_UNESCAPED_SLASHES));
+
+        $qrcode_html = '';
+
+        try {
+            $qrcode_html = QrCode::margin(0)
+                ->size(180)
+                ->generate($invitation_url_for_blade);
+        } catch (RuntimeException $e) {
+            // libxml 拡張機能がサーバーにインストールされていない場合、
+            // QRコードは表示しない
+            $qrcode_html = '';
+        }
+
         return view('v2.circles.users.index')
             ->with('circle', $circle)
-            ->with('invitation_url', str_replace('"', '', \json_encode($invitation_url, JSON_UNESCAPED_SLASHES)))
+            ->with('invitation_url', $invitation_url_for_blade)
+            ->with('qrcode_html', $qrcode_html)
             ->with('share_json', \json_encode([
                 'url' => $invitation_url,
             ], JSON_UNESCAPED_SLASHES));

--- a/resources/views/v2/circles/users/index.blade.php
+++ b/resources/views/v2/circles/users/index.blade.php
@@ -21,13 +21,13 @@
                 <input id="invitation_url" type="text" class="form-control" name="invitation_url"
                     value="{{ $invitation_url }}" readonly>
             </list-view-form-group>
-            <list-view-card>
-                <div class="text-center">
-                    {!! QrCode::margin(0)
-                    ->size(180)
-                    ->generate($invitation_url) !!}
-                </div>
-            </list-view-card>
+            @if (!empty($qrcode_html))
+                <list-view-card>
+                    <div class="text-center">
+                        {!! $qrcode_html !!}
+                    </div>
+                </list-view-card>
+            @endif
             <list-view-action-btn button v-on:click="share({{ $share_json }})" icon-class="far fa-share-square">
                 URLを共有
             </list-view-action-btn>


### PR DESCRIPTION
## 実装内容
<!-- どんな実装をしたのか -->

バリューサーバーなど、QRコード生成に必要な libxml 拡張がサーバーにインストールされていない場合、招待画面で 500 エラーとなってしまうのを解消しました。

↓libxml 拡張がインストールされていない場合、QRコードは表示されないようにしました。

<img width="800" alt="スクリーンショット 2020-06-17 1 27 16" src="https://user-images.githubusercontent.com/6687653/84801362-082d4e00-b03a-11ea-821b-8be54288fbb4.png">

## 懸念点

## レビュワーに見て欲しい点
バリューサーバーをレンタルしていないと動作確認はできないと思うので、とりあえずコードに問題がないかだけ軽くチェックしてもらえると助かります。

## 参考URL
