### PR TITLE
【スタッフ/企画情報/新規作成】 Routeが存在しない #201

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -217,7 +217,7 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
                 Route::get('/{circle}/edit', 'Staff\Circles\EditAction')->name('edit');
                 Route::patch('/{circle}', 'Staff\Circles\UpdateAction')->name('update');
                 Route::get('/create', 'Staff\Circles\CreateAction')->name('create');
-                Route::post('/', 'Staff\Circles\StoreAction')->name('new');
+                Route::post('/', 'Staff\Circles\StoreAction')->name('store');
 
                 // 企画所属者宛のメール送信
                 Route::get('/{circle}/email', 'Staff\Circles\SendEmails\IndexAction')->name('email');

--- a/tests/Feature/Http/Controllers/Staff/Circles/CreateActionTest.php
+++ b/tests/Feature/Http/Controllers/Staff/Circles/CreateActionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Staff\Circles;
+
+use App\Eloquents\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class CreateActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $staff;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->staff = factory(User::class)->states('staff')->create();
+    }
+
+    /**
+     * @test
+     */
+    public function 企画の新規作成フォームが表示される()
+    {
+        $responce = $this->actingAs($this->staff)
+                        ->withSession(['staff_authorized' => true])
+                        ->get(
+                            route('staff.circles.create')
+                        );
+
+        $responce->assertOk();
+    }
+}


### PR DESCRIPTION
## 実装内容
close #201 
<!-- どんな実装をしたのか -->
- web.php の `staff.circles.new` をコントローラー名と合わせるために `staff.circles.store` に変更しました
- 1つしかメソッドがありませんが Staff/Circles/CreateAction.php のテストを書きました

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
