### PR TITLE
【Staff/ポータル情報の設定】企画セレクタを表示しない #199

### DIFF
--- a/resources/views/includes/top_circle_selector.blade.php
+++ b/resources/views/includes/top_circle_selector.blade.php
@@ -3,7 +3,8 @@
 @auth
     @if (count($selectorService->getSelectableCirclesList(Auth::user(), Request::path())) >= 2 &&
         empty(trim($__env->yieldContent('no_circle_selector')) /* ← no_circle_selector という section がセットされていない場合 true */) &&
-        !Request::is('staff*'))
+        !Request::is('staff*') &&
+        !Request::is('admin*'))
         <circle-selector-dropdown
             v-bind:circles="{{ $selectorService->getJsonForCircleSelectorDropdown(Auth::user(), Request::path()) }}"
             v-bind:selected-circle-id="{{ $selectorService->getCircle()->id }}"


### PR DESCRIPTION
## 実装内容
close #199 
<!-- どんな実装をしたのか -->
- `/admin` から始まるURLでは企画セレクターを表示しないようにしました

## 懸念点

## レビュワーに見て欲しい点
ポータル設定で企画セレクターが表示されないこと

## 参考URL
