### PR TITLE
【お知らせ他】配布資料へのリンクをMarkdownの本文に含めると、Turbolinksが原因で文字化けしたページが表示されてしまう #223

### DIFF
--- a/resources/js/v2/components/MarkdownEditor.vue
+++ b/resources/js/v2/components/MarkdownEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div data-turbolinks="false">
     <vue-simplemde
       v-model="content"
       ref="markdownEditor"

--- a/resources/views/circles/show.blade.php
+++ b/resources/views/circles/show.blade.php
@@ -45,7 +45,7 @@
         @if ($circle->hasRejected() && isset($circle->status_reason))
         <list-view>
             <template v-slot:title>不受理となった理由</template>
-            <list-view-card class="markdown">
+            <list-view-card data-turbolinks="false" class="markdown">
                 @markdown($circle->status_reason)
             </list-view-card>
         </list-view>

--- a/resources/views/circles/terms.blade.php
+++ b/resources/views/circles/terms.blade.php
@@ -11,7 +11,7 @@
 <app-container medium>
     <list-view>
         <template v-slot:title>企画参加登録を始める前に</template>
-        <list-view-card class="markdown">
+        <list-view-card data-turbolinks="false" class="markdown">
             @markdown($description)
         </list-view-card>
     </list-view>

--- a/resources/views/forms/answers/form.blade.php
+++ b/resources/views/forms/answers/form.blade.php
@@ -28,7 +28,7 @@
 
         <app-header>
             <template v-slot:title>{{ $form->name }}</template>
-            <div class="markdown">
+            <div data-turbolinks="false" class="markdown">
                 <p class="text-muted">
                     受付期間 : @datetime($form->open_at)〜@datetime($form->close_at)
                     @if (!$form->isOpen())

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -168,7 +168,7 @@
                         @datetime($next_schedule->start_at)〜 • {{ $next_schedule->place }}
                     </template>
                     @isset ($next_schedule->description)
-                        <div class="markdown">
+                        <div data-turbolinks="false" class="markdown">
                             <hr>
                             @markdown($next_schedule->description)
                         </div>

--- a/resources/views/includes/question.blade.php
+++ b/resources/views/includes/question.blade.php
@@ -1,6 +1,6 @@
 @if ($question->type === 'heading')
     <question-heading name="{{ $question->name }}">
-        <div class="markdown">
+        <div data-turbolinks="false" class="markdown">
             @markdown($question->description)
         </div>
     </question-heading>

--- a/resources/views/pages/show.blade.php
+++ b/resources/views/pages/show.blade.php
@@ -23,7 +23,7 @@
             </div>
         @endif
     </app-header>
-    <app-container class="markdown py-spacing-lg">
+    <app-container data-turbolinks="false" class="markdown py-spacing-lg">
         @markdown($page->body)
     </app-container>
 @endsection

--- a/resources/views/schedules/show.blade.php
+++ b/resources/views/schedules/show.blade.php
@@ -20,7 +20,7 @@
         </div>
     </app-header>
     <app-container class="py-spacing-lg">
-        <div class="markdown">
+        <div data-turbolinks="false" class="markdown">
             @markdown($schedule->description)
         </div>
     </app-container>

--- a/resources/views/staff/forms/answers/form.blade.php
+++ b/resources/views/staff/forms/answers/form.blade.php
@@ -20,7 +20,7 @@
 
         <app-header>
             <template v-slot:title>{{ $form->name }}</template>
-            <div class="markdown">
+            <div data-turbolinks="false" class="markdown">
                 @markdown($form->description)
             </div>
         </app-header>


### PR DESCRIPTION
## 実装内容
close #223 
<!-- どんな実装をしたのか -->

お知らせ等、Markdown 内のリンクは data-turbolinks="false" とみなされるようにしました。

## 懸念点

## レビュワーに見て欲しい点

Markdown 内に配布資料へのリンクを貼っても、正常にリンクアクセスできるかどうか。

## 参考URL
