### PR TITLE
【Staff/ユーザー情報管理】最終ログイン日時を記録 #76

### DIFF
--- a/app/Eloquents/User.php
+++ b/app/Eloquents/User.php
@@ -64,6 +64,7 @@ class User extends Authenticatable
         'email_verified_at',
         'univemail_verified_at',
         'signed_up_at',
+        'last_accessed_at',
     ];
 
     protected $casts = [

--- a/app/Eloquents/User.php
+++ b/app/Eloquents/User.php
@@ -278,4 +278,29 @@ class User extends Authenticatable
     {
         return $circle->leader->first()->id === $this->id;
     }
+
+    /**
+     * 最終アクセスをいい感じに返す
+     * @return String
+     */
+    public function formatLastAccessedAt()
+    {
+        $last_accessed_at = $this->last_accessed_at;
+        if (empty($last_accessed_at)) {
+            return "-";
+        }
+        if (now()->subHour()->lte($last_accessed_at)) {
+            return '1時間以内';
+        }
+        if (now()->subDay()->lte($last_accessed_at)) {
+            return "{$last_accessed_at->diffInHours(now())}時間前";
+        }
+        if (now()->subMonth()->lte($last_accessed_at)) {
+            return "{$last_accessed_at->diffInDays(now())}日前";
+        }
+        if (now()->subYear()->lte($last_accessed_at)) {
+            return "{$last_accessed_at->diffInMonths(now())}ヶ月前";
+        }
+        return "1年以上前";
+    }
 }

--- a/app/GridMakers/UsersGridMaker.php
+++ b/app/GridMakers/UsersGridMaker.php
@@ -7,6 +7,7 @@ namespace App\GridMakers;
 use Illuminate\Database\Eloquent\Builder;
 use App\Eloquents\User;
 use App\GridMakers\Concerns\UseEloquent;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 
 class UsersGridMaker implements GridMakable
@@ -39,6 +40,7 @@ class UsersGridMaker implements GridMakable
             'is_admin',
             'email_verified_at',
             'univemail_verified_at',
+            'last_accessed_at',
             'notes',
             'created_at',
             'updated_at',
@@ -63,6 +65,7 @@ class UsersGridMaker implements GridMakable
             'is_admin' => ['type' => 'bool'],
             'email_verified_at' => ['type' => 'isNull'],
             'univemail_verified_at' => ['type' => 'isNull'],
+            'last_accessed_at' => ['type' => 'datetime'],
             'notes' => ['type' => 'string'],
             'created_at' => ['type' => 'datetime'],
             'updated_at' => ['type' => 'datetime'],
@@ -87,6 +90,7 @@ class UsersGridMaker implements GridMakable
             'is_admin',
             'email_verified_at',
             'univemail_verified_at',
+            'last_accessed_at',
             'notes',
             'created_at',
             'updated_at',
@@ -101,6 +105,9 @@ class UsersGridMaker implements GridMakable
         $item = [];
         foreach ($this->keys() as $key) {
             switch ($key) {
+                case 'last_accessed_at':
+                    $item[$key] = $this->formatLastAccessedAt($record->last_accessed_at);
+                    break;
                 case 'created_at':
                     $item[$key] = $record->created_at->format('Y/m/d H:i:s');
                     break;
@@ -117,5 +124,30 @@ class UsersGridMaker implements GridMakable
     protected function model(): Model
     {
         return new User();
+    }
+
+    /**
+     * 最終アクセスを変換して返す関数
+     * @param Carbon|null $last_accessed_at
+     * @return String
+     */
+    private function formatLastAccessedAt(?Carbon $last_accessed_at)
+    {
+        if (empty($last_accessed_at)) {
+            return "-";
+        }
+        if (now()->subHour()->lte($last_accessed_at)) {
+            return '1時間以内';
+        }
+        if (now()->subDay()->lte($last_accessed_at)) {
+            return "{$last_accessed_at->diffInHours(now())}時間前";
+        }
+        if (now()->subMonth()->lte($last_accessed_at)) {
+            return "{$last_accessed_at->diffInDays(now())}日前";
+        }
+        if (now()->subYear()->lte($last_accessed_at)) {
+            return "{$last_accessed_at->diffInMonths(now())}ヶ月前";
+        }
+        return "1年以上前";
     }
 }

--- a/app/GridMakers/UsersGridMaker.php
+++ b/app/GridMakers/UsersGridMaker.php
@@ -105,7 +105,7 @@ class UsersGridMaker implements GridMakable
         foreach ($this->keys() as $key) {
             switch ($key) {
                 case 'last_accessed_at':
-                    $item[$key] = $this->formatLastAccessedAt($record->last_accessed_at);
+                    $item[$key] = $record->formatLastAccessedAt();
                     break;
                 case 'created_at':
                     $item[$key] = $record->created_at->format('Y/m/d H:i:s');
@@ -123,30 +123,5 @@ class UsersGridMaker implements GridMakable
     protected function model(): Model
     {
         return new User();
-    }
-
-    /**
-     * 最終アクセスを変換して返す関数
-     * @param Carbon|null $last_accessed_at
-     * @return String
-     */
-    private function formatLastAccessedAt(?Carbon $last_accessed_at)
-    {
-        if (empty($last_accessed_at)) {
-            return "-";
-        }
-        if (now()->subHour()->lte($last_accessed_at)) {
-            return '1時間以内';
-        }
-        if (now()->subDay()->lte($last_accessed_at)) {
-            return "{$last_accessed_at->diffInHours(now())}時間前";
-        }
-        if (now()->subMonth()->lte($last_accessed_at)) {
-            return "{$last_accessed_at->diffInDays(now())}日前";
-        }
-        if (now()->subYear()->lte($last_accessed_at)) {
-            return "{$last_accessed_at->diffInMonths(now())}ヶ月前";
-        }
-        return "1年以上前";
     }
 }

--- a/app/GridMakers/UsersGridMaker.php
+++ b/app/GridMakers/UsersGridMaker.php
@@ -65,7 +65,6 @@ class UsersGridMaker implements GridMakable
             'is_admin' => ['type' => 'bool'],
             'email_verified_at' => ['type' => 'isNull'],
             'univemail_verified_at' => ['type' => 'isNull'],
-            'last_accessed_at' => ['type' => 'datetime'],
             'notes' => ['type' => 'string'],
             'created_at' => ['type' => 'datetime'],
             'updated_at' => ['type' => 'datetime'],

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -38,6 +38,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\Turbolinks::class,
+            \App\Http\Middleware\UpdateLastAccessedAt::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/UpdateLastAccessedAt.php
+++ b/app/Http/Middleware/UpdateLastAccessedAt.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Carbon\Carbon;
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class UpdateLastAccessedAt
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (Auth::check()) {
+            $user = $request->user();
+            if (empty($user->last_accessed_at) || now()->subHour()->gte($user->last_accessed_at)) {
+                $user->last_accessed_at = now();
+                $user->save();
+            }
+        }
+        return $next($request);
+    }
+}

--- a/application/controllers/Home_staff.php
+++ b/application/controllers/Home_staff.php
@@ -59,6 +59,7 @@ class Home_staff extends MY_Controller
         $this->grocery_crud->display_as('is_staff', 'スタッフ');
         $this->grocery_crud->display_as('is_admin', '管理者');
         $this->grocery_crud->display_as('notes', 'ｽﾀｯﾌ用ﾒﾓ');
+        $this->grocery_crud->display_as('last_accessed_at', '最終アクセス');
 
         // id順に表示する
         $this->grocery_crud->order_by('id', 'asc');
@@ -516,6 +517,7 @@ class Home_staff extends MY_Controller
             'tel',
             'is_staff',
             'is_admin',
+            'last_accessed_at',
             'created_at',
             'updated_at',
             'notes'
@@ -563,6 +565,7 @@ class Home_staff extends MY_Controller
 
         $this->grocery_crud->callback_column('identify', array($this, '_crud_user_identify'));
         $this->grocery_crud->callback_column('verify', array($this, '_crud_email_verified'));
+        $this->grocery_crud->callback_column('last_accessed_at', array($this, '_crud_last_accessed_at'));
 
         $vars += (array)$this->grocery_crud->render();
 
@@ -602,6 +605,31 @@ class Home_staff extends MY_Controller
             return '<span class="text-success">確認済み</span>';
         }
         return '<span class="text-danger">未確認</span> - <a href="/staff/users/'. $row->id. '/verify">本人確認を完了する</a>';
+    }
+
+    /**
+     * 最終アクセスのフォーマットを返すコールバック関数
+     */
+    public function _crud_last_accessed_at($value, $row)
+    {
+        if (empty($value)) {
+            return "-";
+        }
+
+        $last_accessed_at = new Carbon\Carbon($value);
+        if (now()->subHour()->lte($last_accessed_at)) {
+            return '1時間以内';
+        }
+        if (now()->subDay()->lte($last_accessed_at)) {
+            return "{$last_accessed_at->diffInHours(now())}時間前";
+        }
+        if (now()->subMonth()->lte($last_accessed_at)) {
+            return "{$last_accessed_at->diffInDays(now())}日前";
+        }
+        if (now()->subYear()->lte($last_accessed_at)) {
+            return "{$last_accessed_at->diffInMonths(now())}ヶ月前";
+        }
+        return "1年以上前";
     }
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -27,6 +27,7 @@ $factory->define(User::class, function (Faker $faker) {
         'email_verified_at' => now(),
         'univemail_verified_at' => now(),
         'signed_up_at' => now(),
+        'last_accessed_at' => now(),
         'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
         'remember_token' => Str::random(10),
     ];

--- a/database/migrations/2020_07_21_213552_add_last_accessed_at_to_users.php
+++ b/database/migrations/2020_07_21_213552_add_last_accessed_at_to_users.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLastAccessedAtToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dateTime('last_accessed_at')->nullable()->after('signed_up_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('last_accessed_at');
+        });
+    }
+}

--- a/resources/views/layouts/no_drawer.blade.php
+++ b/resources/views/layouts/no_drawer.blade.php
@@ -83,9 +83,9 @@
                 @endif
                 @yield('content')
             </div>
-            <app-credit>
+            <app-footer>
                 {{ config('app.name') }}
-            </app-credit>
+            </app-footer>
         </div>
     </div>
 

--- a/resources/views/staff/users/index.blade.php
+++ b/resources/views/staff/users/index.blade.php
@@ -20,6 +20,7 @@
             is_admin: '管理者',
             email_verified_at: 'メール認証',
             univemail_verified_at: '本人確認',
+            last_accessed_at: '最終アクセス',
             notes: 'スタッフ用メモ',
             created_at: '作成日時',
             updated_at: '更新日時',

--- a/tests/Feature/GridMakers/UsersGridMakerTest.php
+++ b/tests/Feature/GridMakers/UsersGridMakerTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\GridMakers;
 
 use App\Eloquents\User;
 use App\GridMakers\UsersGridMaker;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\App;
 use Tests\TestCase;
 
@@ -19,6 +21,8 @@ class UsersGridMakerTest extends TestCase
         parent::setUp();
 
         $this->usersGridMaker = App::make(UsersGridMaker::class);
+        Carbon::setTestNow(new CarbonImmutable('2020-02-08 00:00:00'));
+        CarbonImmutable::setTestNow(new CarbonImmutable('2020-02-08 00:00:00'));
     }
 
     /**
@@ -27,12 +31,14 @@ class UsersGridMakerTest extends TestCase
     public function map()
     {
         $user = factory(User::class)->make([
+            'last_accessed_at' => '2020-02-02 02:02:02',
             'created_at' => '2020-02-02 02:02:02',
             'updated_at' => '2020-02-02 02:02:02',
         ]);
 
         $result = $this->usersGridMaker->map($user);
 
+        $this->assertSame('5日前', $result['last_accessed_at']); // 02:02:02 を迎えていないので 5日前 と返ってくる
         $this->assertSame('2020/02/02 02:02:02', $result['created_at']);
         $this->assertSame('2020/02/02 02:02:02', $result['updated_at']);
     }

--- a/tests/Feature/GridMakers/UsersGridMakerTest.php
+++ b/tests/Feature/GridMakers/UsersGridMakerTest.php
@@ -42,4 +42,26 @@ class UsersGridMakerTest extends TestCase
         $this->assertSame('2020/02/02 02:02:02', $result['created_at']);
         $this->assertSame('2020/02/02 02:02:02', $result['updated_at']);
     }
+
+    public function formatLastAccessedAt_provider()
+    {
+        return [
+            [new CarbonImmutable('2020-02-07 23:23:23'), '1時間以内'],
+            [new CarbonImmutable('2020-02-01 01:23:45'), '6日前'],
+            [new CarbonImmutable('2019-10-31 19:10:31'), '3ヶ月前'],
+            [new CarbonImmutable('2012-05-22 09:30:00'), '1年以上前']
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider formatLastAccessedAt_provider
+     */
+    public function formatLastAccessedAt(CarbonImmutable $last_accessed_at, string $expected)
+    {
+        $user = factory(User::class)->make([
+            'last_accessed_at' => $last_accessed_at,
+        ]);
+        $this->assertSame($expected, $user->formatLastAccessedAt());
+    }
 }


### PR DESCRIPTION
## 実装内容
close #76 
<!-- どんな実装をしたのか -->
- 最終アクセスを記録するようにしました
- 1時間以内の場合は値を更新しません
- スタッフモードのユーザー情報管理では「◯時間前」「◯日前」などと表示するようにしました

## 懸念点

## レビュワーに見て欲しい点
- 1時間以内の場合は更新されないこと

## 参考URL
