### PR TITLE
アイコンを一般モードとStaffで揃える

### DIFF
--- a/application/controllers/Home_staff.php
+++ b/application/controllers/Home_staff.php
@@ -1425,7 +1425,7 @@ class Home_staff extends MY_Controller
                     "url" => "home_staff",
                 ],
                 "pages" => [
-                    "icon" => "newspaper-o",
+                    "icon" => "bullhorn",
                     "name" => "お知らせ管理",
                     "url" => "home_staff/pages",
                 ],

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -24,7 +24,6 @@
 
     <!-- Scripts -->
     @prepend('js')
-    <script defer src="https://use.fontawesome.com/releases/v5.8.1/js/v4-shims.js"></script>
     <script src="{{ mix('js/manifest.js') }}" defer></script>
     <script src="{{ mix('js/vendor.js') }}" defer></script>
     <script src="{{ mix('js/app.js') }}" defer></script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -24,6 +24,7 @@
 
     <!-- Scripts -->
     @prepend('js')
+    <script defer src="https://use.fontawesome.com/releases/v5.8.1/js/v4-shims.js"></script>
     <script src="{{ mix('js/manifest.js') }}" defer></script>
     <script src="{{ mix('js/vendor.js') }}" defer></script>
     <script src="{{ mix('js/app.js') }}" defer></script>


### PR DESCRIPTION
## 実装内容
close #72 
一般モードにおける「お知らせ」アイコンと、スタッフモードにおける「お知らせ」アイコンが違うため揃えました。

## 懸念点
FontAwesome v4 に bullhorn アイコンがない場合、 v5-shim の導入を行いました。

## レビュワーに見て欲しい点
PHPUnit等で変更しなければならない点がないかどうか。