### PR TITLE
【タグ】タグを削除したら関連テーブルの内容も削除する #307

### DIFF
--- a/app/Http/Controllers/Staff/Tags/CreateAction.php
+++ b/app/Http/Controllers/Staff/Tags/CreateAction.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Tags;
+
+use App\Http\Controllers\Controller;
+
+class CreateAction extends Controller
+{
+    public function __invoke()
+    {
+        return view('staff.tags.form');
+    }
+}

--- a/app/Http/Controllers/Staff/Tags/DeleteAction.php
+++ b/app/Http/Controllers/Staff/Tags/DeleteAction.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Tags;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Eloquents\Tag;
+
+class DeleteAction extends Controller
+{
+    public function __invoke(Tag $tag)
+    {
+        return view('staff.tags.delete')
+            ->with('tag', $tag);
+    }
+}

--- a/app/Http/Controllers/Staff/Tags/DestroyAction.php
+++ b/app/Http/Controllers/Staff/Tags/DestroyAction.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Tags;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Eloquents\Tag;
+
+class DestroyAction extends Controller
+{
+    public function __invoke(Tag $tag)
+    {
+        $tag->delete();
+        return redirect('/home_staff/tags');
+    }
+}

--- a/app/Http/Controllers/Staff/Tags/EditAction.php
+++ b/app/Http/Controllers/Staff/Tags/EditAction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Tags;
+
+use App\Http\Controllers\Controller;
+use App\Eloquents\Tag;
+
+class EditAction extends Controller
+{
+    public function __invoke(Tag $tag)
+    {
+        return view('staff.tags.form')
+            ->with('tag', $tag);
+    }
+}

--- a/app/Http/Controllers/Staff/Tags/StoreAction.php
+++ b/app/Http/Controllers/Staff/Tags/StoreAction.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Tags;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Staff\Tags\TagRequest;
+use App\Eloquents\Tag;
+
+class StoreAction extends Controller
+{
+    public function __invoke(TagRequest $request)
+    {
+        Tag::create([
+            'name' => $request->validated()['name'],
+        ]);
+
+        return redirect()
+            ->route('staff.tags.create')
+            ->with('topAlert.title', 'タグを作成しました');
+    }
+}

--- a/app/Http/Controllers/Staff/Tags/UpdateAction.php
+++ b/app/Http/Controllers/Staff/Tags/UpdateAction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Tags;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Staff\Tags\TagRequest;
+use App\Eloquents\Tag;
+
+class UpdateAction extends Controller
+{
+    public function __invoke(TagRequest $request, Tag $tag)
+    {
+        $tag->name = $request->validated()['name'];
+        $tag->save();
+
+        return redirect()
+            ->route('staff.tags.edit', ['tag' => $tag])
+            ->with('topAlert.title', 'タグを更新しました');
+    }
+}

--- a/app/Http/Requests/Staff/Tags/TagRequest.php
+++ b/app/Http/Requests/Staff/Tags/TagRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests\Staff\Tags;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * バリデーションエラーのカスタム属性の取得
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            'name' => 'タグ',
+        ];
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', Rule::unique('tags')->ignore($this->tag ?? null)],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'name.unique' => '同名のタグが既に存在します。',
+        ];
+    }
+}

--- a/application/controllers/Home_staff.php
+++ b/application/controllers/Home_staff.php
@@ -812,6 +812,15 @@ class Home_staff extends MY_Controller
         $vars["page_title"] = "企画タグ管理";
         $vars["main_page_type"] = "tags";
 
+        if ($this->uri->segment(3) === "add") {
+            codeigniter_redirect("/staff/tags/create");
+        }
+
+        if ($this->uri->segment(3) === "edit") {
+            $tag_id = (int)$this->uri->segment(4);
+            codeigniter_redirect("/staff/tags/$tag_id/edit");
+        }
+
         $this->grocery_crud->set_table('tags');
         $this->grocery_crud->set_subject('企画タグ');
         $this->grocery_crud->display_as('id', 'タグID');

--- a/application/controllers/Home_staff.php
+++ b/application/controllers/Home_staff.php
@@ -817,7 +817,7 @@ class Home_staff extends MY_Controller
         $this->grocery_crud->display_as('id', 'タグID');
         $this->grocery_crud->display_as('name', 'タグ');
         $this->grocery_crud->display_as('circles', '企画');
-        $this->grocery_crud->set_delete_tag();
+        $this->grocery_crud->set_delete_confirm_url(base_url('/staff/tags/{{url}}/delete'));
 
         $this->grocery_crud->columns(
             'id',

--- a/application/controllers/Home_staff.php
+++ b/application/controllers/Home_staff.php
@@ -817,6 +817,7 @@ class Home_staff extends MY_Controller
         $this->grocery_crud->display_as('id', 'タグID');
         $this->grocery_crud->display_as('name', 'タグ');
         $this->grocery_crud->display_as('circles', '企画');
+        $this->grocery_crud->set_delete_tag();
 
         $this->grocery_crud->columns(
             'id',

--- a/application/controllers/Home_staff.php
+++ b/application/controllers/Home_staff.php
@@ -817,7 +817,7 @@ class Home_staff extends MY_Controller
         $this->grocery_crud->display_as('id', 'タグID');
         $this->grocery_crud->display_as('name', 'タグ');
         $this->grocery_crud->display_as('circles', '企画');
-        $this->grocery_crud->set_delete_confirm_url(base_url('/staff/tags/{{url}}/delete'));
+        $this->grocery_crud->set_delete_confirm_url(base_url('/staff/tags/{{id}}/delete'));
 
         $this->grocery_crud->columns(
             'id',

--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -1445,7 +1445,7 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
         $data->unset_print			= $this->unset_print;
         $data->set_editor			= $this->set_editor;
         $data->set_copy_url			= $this->set_copy_url;
-        $data->set_delete_tag		= $this->set_delete_tag;
+        $data->delete_confirm_url	= $this->delete_confirm_url;
 
         $default_per_page = $this->config->default_per_page;
         $data->paging_options = $this->config->paging_options;
@@ -3303,7 +3303,7 @@ class Grocery_CRUD extends grocery_CRUD_States
     protected $unset_read_fields	= null;
     protected $set_editor			= false;
     protected $set_copy_url			= false;
-    protected $set_delete_tag		= false;
+    protected $delete_confirm_url	= null;
 
     /* Callbacks */
     protected $callback_before_insert 	= null;
@@ -3702,11 +3702,13 @@ class Grocery_CRUD extends grocery_CRUD_States
     }
 
     /**
-     * タグ削除用のボタンを配置するための関数
+     * 削除する前に確認画面を表示したい場合、この関数を実行する
+     *
+     * $url 中の {{id}} 部分がレコード id に置換される
      */
-    public function set_delete_tag()
+    public function set_delete_confirm_url(string $url)
     {
-        $this->set_delete_tag = true;
+        $this->delete_confirm_url = $url;
 
         return $this;
     }

--- a/application/libraries/Grocery_CRUD.php
+++ b/application/libraries/Grocery_CRUD.php
@@ -1445,6 +1445,7 @@ class grocery_CRUD_Layout extends grocery_CRUD_Model_Driver
         $data->unset_print			= $this->unset_print;
         $data->set_editor			= $this->set_editor;
         $data->set_copy_url			= $this->set_copy_url;
+        $data->set_delete_tag		= $this->set_delete_tag;
 
         $default_per_page = $this->config->default_per_page;
         $data->paging_options = $this->config->paging_options;
@@ -3302,6 +3303,7 @@ class Grocery_CRUD extends grocery_CRUD_States
     protected $unset_read_fields	= null;
     protected $set_editor			= false;
     protected $set_copy_url			= false;
+    protected $set_delete_tag		= false;
 
     /* Callbacks */
     protected $callback_before_insert 	= null;
@@ -3695,6 +3697,16 @@ class Grocery_CRUD extends grocery_CRUD_States
     public function set_copy_url()
     {
         $this->set_copy_url = true;
+
+        return $this;
+    }
+
+    /**
+     * タグ削除用のボタンを配置するための関数
+     */
+    public function set_delete_tag()
+    {
+        $this->set_delete_tag = true;
 
         return $this;
     }

--- a/database/migrations/2020_08_23_234631_add_foreign_keys_in_tags.php
+++ b/database/migrations/2020_08_23_234631_add_foreign_keys_in_tags.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeysInTags extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('circle_tag', function (Blueprint $table) {
+            $table->foreign('tag_id')
+                ->references('id')->on('tags')
+                ->onDelete('cascade');
+        });
+        Schema::table('page_viewable_tags', function (Blueprint $table) {
+            $table->foreign('tag_id')
+                ->references('id')->on('tags')
+                ->onDelete('cascade');
+        });
+        Schema::table('form_answerable_tags', function (Blueprint $table) {
+            $table->foreign('tag_id')
+                ->references('id')->on('tags')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('circle_tag', function (Blueprint $table) {
+            $table->dropForeign(['tag_id']);
+        });
+        Schema::table('page_viewable_tags', function (Blueprint $table) {
+            $table->dropForeign(['tag_id']);
+        });
+        Schema::table('form_answerable_tags', function (Blueprint $table) {
+            $table->dropForeign(['tag_id']);
+        });
+    }
+}

--- a/public/assets/grocery_crud/themes/crud-bootstrap/views/list.php
+++ b/public/assets/grocery_crud/themes/crud-bootstrap/views/list.php
@@ -30,13 +30,13 @@
 			<?php if(!$unset_delete || !$unset_edit || !$unset_read || !empty($actions)){?>
 			<td align="left" width='20%'>
 				<div class='tools'>
-					<?php if(!$unset_delete && !$set_delete_tag){?>
+					<?php if(!$unset_delete && empty($delete_confirm_url)){?>
 						<a href='<?php echo $row->delete_url?>' title='<?php echo $this->l('list_delete')?> <?php echo $subject?>' class="btn btn-danger delete-row">
 							<i class="fa fa-trash" aria-hidden="true"></i>
 						</a>
 					<?php }?>
-					<?php if($set_delete_tag){?>
-						<a href='<?php echo base_url("/staff/tags/{$row->id}/delete") ?>' title='削除' class="btn btn-danger delete-tag-row">
+					<?php if(!empty($delete_confirm_url)){?>
+						<a href='<?php echo str_replace('{{url}}', $row->id, $delete_confirm_url) ?>' title='削除' class="btn btn-danger delete-tag-row">
 							<i class="fa fa-trash" aria-hidden="true"></i>
 						</a>
 					<?php }?>

--- a/public/assets/grocery_crud/themes/crud-bootstrap/views/list.php
+++ b/public/assets/grocery_crud/themes/crud-bootstrap/views/list.php
@@ -30,9 +30,19 @@
 			<?php if(!$unset_delete || !$unset_edit || !$unset_read || !empty($actions)){?>
 			<td align="left" width='20%'>
 				<div class='tools'>
-					<?php if(!$unset_delete){?>
+					<?php if(!$unset_delete && !$set_delete_tag){?>
 						<a href='<?php echo $row->delete_url?>' title='<?php echo $this->l('list_delete')?> <?php echo $subject?>' class="btn btn-danger delete-row">
 							<i class="fa fa-trash" aria-hidden="true"></i>
+						</a>
+					<?php }?>
+					<?php if($set_delete_tag){?>
+						<a href='<?php echo base_url("/staff/tags/{$row->id}/delete") ?>' title='削除' class="btn btn-danger delete-tag-row">
+							<i class="fa fa-trash" aria-hidden="true"></i>
+						</a>
+					<?php }?>
+                    <?php if($set_editor){?>
+						<a href='<?php echo base_url($row->editor_url) ?>' title='エディターで編集' class="btn btn-primary edit-row">
+							<i class="fa fa-edit" aria-hidden="true"></i>
 						</a>
 					<?php }?>
 					<?php if(!$unset_edit){?>

--- a/public/assets/grocery_crud/themes/crud-bootstrap/views/list.php
+++ b/public/assets/grocery_crud/themes/crud-bootstrap/views/list.php
@@ -36,7 +36,7 @@
 						</a>
 					<?php }?>
 					<?php if(!empty($delete_confirm_url)){?>
-						<a href='<?php echo str_replace('{{url}}', $row->id, $delete_confirm_url) ?>' title='削除' class="btn btn-danger delete-tag-row">
+						<a href='<?php echo str_replace('{{id}}', $row->id, $delete_confirm_url) ?>' title='削除' class="btn btn-danger delete-tag-row">
 							<i class="fa fa-trash" aria-hidden="true"></i>
 						</a>
 					<?php }?>

--- a/public/assets/grocery_crud/themes/crud-bootstrap/views/list.php
+++ b/public/assets/grocery_crud/themes/crud-bootstrap/views/list.php
@@ -40,11 +40,6 @@
 							<i class="fa fa-trash" aria-hidden="true"></i>
 						</a>
 					<?php }?>
-                    <?php if($set_editor){?>
-						<a href='<?php echo base_url($row->editor_url) ?>' title='エディターで編集' class="btn btn-primary edit-row">
-							<i class="fa fa-edit" aria-hidden="true"></i>
-						</a>
-					<?php }?>
 					<?php if(!$unset_edit){?>
 						<a href='<?php echo $row->edit_url?>' title='<?php echo $this->l('list_edit')?> <?php echo $subject?>' class="btn btn-primary edit-row">
 							<i class="fa fa-pencil" aria-hidden="true"></i>

--- a/resources/js/v2/components/ListViewActionBtn.vue
+++ b/resources/js/v2/components/ListViewActionBtn.vue
@@ -5,6 +5,7 @@
     :button="button"
     :submit="submit"
     class="action-btn"
+    :class="{ 'is-danger': danger }"
     @click="onClick"
   >
     <i :class="iconClass" v-if="iconClass" class="action-btn__icon"></i>
@@ -36,6 +37,10 @@ export default {
       type: Boolean,
       default: false
     },
+    danger: {
+      type: Boolean,
+      default: false
+    },
     iconClass: {
       type: String,
       default: null
@@ -58,9 +63,15 @@ export default {
   justify-content: center;
   padding-bottom: $spacing-md;
   padding-top: $spacing-md;
+  &.is-danger {
+    color: $color-danger;
+  }
   &:disabled {
     color: rgba($color-primary, 0.4);
     cursor: auto;
+    &.is-danger {
+      color: rgba($color-danger, 0.4);
+    }
     &:hover,
     &:active,
     &:focus {
@@ -71,6 +82,9 @@ export default {
   &:not(:disabled):active,
   &:not(:disabled):focus {
     color: $color-primary;
+    &.is-danger {
+      color: $color-danger;
+    }
   }
   &__icon {
     font-size: 1.25rem;

--- a/resources/views/staff/tags/delete.blade.php
+++ b/resources/views/staff/tags/delete.blade.php
@@ -1,0 +1,35 @@
+@extends('layouts.no_drawer')
+
+@section('title', '企画タグの削除')
+
+@section('navbar')
+    <app-nav-bar-back inverse href="{{ url('home_staff/tags') }}" data-turbolinks="false">
+        企画タグ管理
+    </app-nav-bar-back>
+@endsection
+
+@section('content')
+    <app-container medium>
+        <list-view>
+            <template v-slot:title>
+                「{{ $tag->name }}」タグの削除
+            </template>
+
+            <list-view-card>
+                <ul>
+                    <li>企画に「{{ $tag->name }}」タグが紐付けられている場合、紐付け解除されます。企画自体は削除されません</li>
+                    <li>「お知らせを閲覧可能なユーザー」から「{{ $tag->name }}」タグの指定が解除されます。「{{ $tag->name }}」タグ以外に「お知らせを閲覧可能なユーザー」が設定されていないお知らせは、<strong>全ユーザーが閲覧可能となります</strong></li>
+                    <li>申請フォームの「回答可能な企画のタグ」から「{{ $tag->name }}」タグの指定が解除されます。「{{ $tag->name }}」タグ以外に「回答可能な企画のタグ」が設定されていないフォームは、<strong>企画に所属している全ユーザーが回答可能となります</strong></li>
+                </ul>
+            </list-view-card>
+            <form-with-confirm action="{{ route('staff.tags.destroy', ['tag' => $tag]) }}" method="post"
+                    confirm-message="本当に「{{ $tag->name }}」タグを削除しますか？">
+                @method('delete')
+                @csrf
+                <list-view-action-btn danger button submit>
+                    削除する
+                </list-view-action-btn>
+            </form>
+        </list-view>
+    </app-container>
+@endsection

--- a/resources/views/staff/tags/delete.blade.php
+++ b/resources/views/staff/tags/delete.blade.php
@@ -29,7 +29,7 @@
                 <list-view-action-btn danger button submit>
                     削除する
                 </list-view-action-btn>
-            </form>
+            </form-with-confirm>
         </list-view>
     </app-container>
 @endsection

--- a/resources/views/staff/tags/form.blade.php
+++ b/resources/views/staff/tags/form.blade.php
@@ -1,0 +1,51 @@
+@extends('layouts.no_drawer')
+
+@section('title', empty($tag) ? '新規作成 — 企画タグ' : "{$tag->name} — 企画タグ")
+
+@section('navbar')
+    <app-nav-bar-back inverse href="{{ url('/home_staff/tags') }}" data-turbolinks="false">
+        企画タグ管理
+    </app-nav-bar-back>
+@endsection
+
+@section('content')
+    <form method="post" action="{{ empty($tag) ? route('staff.tags.store') : route('staff.tags.update', $tag) }}" enctype="multipart/form-data">
+        @method(empty($tag) ? 'post' : 'patch' )
+        @csrf
+
+        <app-header>
+            @if (empty($tag))
+                <template v-slot:title>企画タグを新規作成</template>
+            @endif
+            @isset ($tag)
+                <template v-slot:title>企画タグを編集</template>
+                <div>タグID : {{ $tag->id }}</div>
+            @endisset
+        </app-header>
+
+        <app-container>
+            <list-view>
+                <list-view-form-group label-for="name">
+                    <template v-slot:label>
+                        タグ名
+                        <app-badge danger>必須</app-badge>
+                    </template>
+                    <input id="name" class="form-control @error('name') is-invalid @enderror" type="text"
+                        name="name" value="{{ old('name', empty($tag) ? '' : $tag->name) }}"
+                        required>
+                    @if ($errors->has('name'))
+                        <template v-slot:invalid>
+                            @foreach ($errors->get('name') as $message)
+                                {{ $message }}
+                            @endforeach
+                        </template>
+                    @endif
+                </list-view-form-group>
+            </list-view>
+
+            <div class="text-center pt-spacing-md pb-spacing">
+                <button type="submit" class="btn is-primary is-wide">保存</button>
+            </div>
+        </app-container>
+    </form>
+@endsection

--- a/routes/staff.php
+++ b/routes/staff.php
@@ -116,6 +116,13 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
                 Route::get('/export', 'Staff\Circles\ExportAction')->name('export');
             });
 
+        Route::prefix('/tags')
+            ->name('tags.')
+            ->group(function () {
+                Route::get('/{tag}/delete', 'Staff\Tags\DeleteAction')->name('delete');
+                Route::delete('/{tag}', 'Staff\Tags\DestroyAction')->name('destroy');
+            });
+
         // メール一斉送信
         Route::get('/send_emails', 'Staff\SendEmails\ListAction')->name('send_emails');
         Route::post('/send_emails', 'Staff\SendEmails\StoreAction');

--- a/routes/staff.php
+++ b/routes/staff.php
@@ -119,6 +119,10 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
         Route::prefix('/tags')
             ->name('tags.')
             ->group(function () {
+                Route::get('/create', 'Staff\Tags\CreateAction')->name('create');
+                Route::post('/', 'Staff\Tags\StoreAction')->name('store');
+                Route::get('/{tag}/edit', 'Staff\Tags\EditAction')->name('edit');
+                Route::patch('/{tag}', 'Staff\Tags\UpdateAction')->name('update');
                 Route::get('/{tag}/delete', 'Staff\Tags\DeleteAction')->name('delete');
                 Route::delete('/{tag}', 'Staff\Tags\DestroyAction')->name('destroy');
             });

--- a/tests/Feature/Http/Controllers/Staff/Tags/DestroyActionTest.php
+++ b/tests/Feature/Http/Controllers/Staff/Tags/DestroyActionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Staff\Tags;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Eloquents\User;
+use App\Eloquents\Circle;
+use App\Eloquents\Tag;
+use App\Eloquents\Page;
+use App\Eloquents\Form;
+
+class DestroyActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function tagテーブルから削除すると関連テーブルからも削除される()
+    {
+        $staff = factory(User::class)->states('staff')->create();
+
+        $circle = factory(Circle::class)->create();
+        $tag = factory(Tag::class)->create();
+        $page = factory(Page::class)->create();
+        $form = factory(Form::class)->create();
+
+        $circle->tags()->attach($tag->id);
+        $page->viewableTags()->attach($tag->id);
+        $form->answerableTags()->attach($tag->id);
+
+        $this->assertDatabaseHas('tags', [
+            'id' => $tag->id,
+        ]);
+
+        $this->assertDatabaseHas('circle_tag', [
+            'circle_id' => $circle->id,
+            'tag_id' => $tag->id,
+        ]);
+
+        $this->assertDatabaseHas('page_viewable_tags', [
+            'page_id' => $page->id,
+            'tag_id' => $tag->id,
+        ]);
+
+        $this->assertDatabaseHas('form_answerable_tags', [
+            'form_id' => $form->id,
+            'tag_id' => $tag->id,
+        ]);
+
+        $response = $this->actingAs($staff)
+            ->withSession(['staff_authorized' => true])
+            ->delete(
+                route('staff.tags.destroy', [
+                    'tag' => $tag->id,
+                ])
+            );
+
+        $this->assertDatabaseMissing('tags', [
+            'id' => $tag->id,
+        ]);
+
+        $this->assertDatabaseMissing('circle_tag', [
+            'circle_id' => $circle->id,
+            'tag_id' => $tag->id,
+        ]);
+
+        $this->assertDatabaseMissing('page_viewable_tags', [
+            'page_id' => $page->id,
+            'tag_id' => $tag->id,
+        ]);
+
+        $this->assertDatabaseMissing('form_answerable_tags', [
+            'form_id' => $form->id,
+            'tag_id' => $tag->id,
+        ]);
+    }
+}


### PR DESCRIPTION
**マイグレーション必要**

## 実装内容
close #307
<!-- どんな実装をしたのか -->

- タグ一覧から削除ボタンを押すと、確認画面が表示されるようにしました
    - 確認画面には注意事項が記載されています
- タグを削除すると、circle_tag、page_viewable_tags、form_answerable_tagsからも削除されるようにしました
    - 企画、お知らせ、フォーム自体は削除されません

## 懸念点

## レビュワーに見て欲しい点
- マイグレーションが正常に動作するか
- タグを削除すると、 tag_id と紐付けられているレコードが削除されるか
- 余計なものが削除されないか・削除されるべきものが削除されるか

## 参考URL
