### PR TITLE
【メール配信】メールにMarkdownの改行が反映されるようにする #335

### DIFF
--- a/resources/views/emails/emails/send_email_service.blade.php
+++ b/resources/views/emails/emails/send_email_service.blade.php
@@ -1,5 +1,5 @@
 @component('mail::message')
 # {{ $subject }}
 
-{!! $body !!}
+{!! preg_replace("/\r\n|\r|\n/", "  \n", $body) !!}
 @endcomponent


### PR DESCRIPTION
## 実装内容
close #335
<!-- どんな実装をしたのか -->

お知らせをメール配信する際、空行なし改行もメール上で反映されるようにしました。

| 修正前 | 修正後 |
| --- | --- |
| <img width="512" alt="スクリーンショット 2020-09-23 1 44 06" src="https://user-images.githubusercontent.com/6687653/93912239-702cb800-fd3e-11ea-8d29-25afea419659.png"> | <img width="512" alt="スクリーンショット 2020-09-23 1 43 39" src="https://user-images.githubusercontent.com/6687653/93912252-7458d580-fd3e-11ea-98b7-1cd1478f4281.png"> |

## 懸念点

この修正によって、表示が崩れてしまうケースがある可能性がある？（そのようなケースは未確認）

## レビュワーに見て欲しい点

## 参考URL
