### PR TITLE
【タグ】 「お知らせ」「申請」が重複しないように #341

### DIFF
--- a/app/Eloquents/Form.php
+++ b/app/Eloquents/Form.php
@@ -62,10 +62,11 @@ class Form extends Model
      */
     public function scopeByCircle($query, ?Circle $circle = null)
     {
-        $query = self::select('forms.*', 'form_answerable_tags.tag_id')
+        $query = self::selectRaw('forms.*, min(`form_answerable_tags`.`tag_id`)')
             ->leftJoin('form_answerable_tags', 'forms.id', '=', 'form_answerable_tags.form_id')
             ->whereNull('form_answerable_tags.tag_id')
-            ->with('answerableTags');
+            ->with('answerableTags')
+            ->groupBy('forms.id');
 
         if (empty($circle)) {
             return $query;

--- a/app/Eloquents/Page.php
+++ b/app/Eloquents/Page.php
@@ -58,10 +58,11 @@ class Page extends Model
      */
     public function scopeByCircle($query, ?Circle $circle = null)
     {
-        $query = self::select('pages.*', 'page_viewable_tags.tag_id')
+        $query = self::selectRaw('`pages`.*, min(`page_viewable_tags`.`tag_id`)')
             ->leftJoin('page_viewable_tags', 'pages.id', '=', 'page_viewable_tags.page_id')
             ->whereNull('page_viewable_tags.tag_id')
-            ->with('viewableTags');
+            ->with('viewableTags')
+            ->groupBy('pages.id');
 
         if (empty($circle)) {
             return $query;

--- a/app/Eloquents/User.php
+++ b/app/Eloquents/User.php
@@ -99,10 +99,12 @@ class User extends Authenticatable
             return $query;
         }
 
-        return self::leftJoin('circle_user', 'users.id', '=', 'circle_user.user_id')
+        return self::select('users.*')
+            ->leftJoin('circle_user', 'users.id', '=', 'circle_user.user_id')
             ->leftJoin('circles', 'circle_user.circle_id', '=', 'circles.id')
             ->leftJoin('circle_tag', 'circles.id', '=', 'circle_tag.circle_id')
-            ->whereIn('circle_tag.tag_id', $tags->pluck('id')->all());
+            ->whereIn('circle_tag.tag_id', $tags->pluck('id')->all())
+            ->groupBy('users.id');
     }
 
     /**

--- a/app/Http/Controllers/HomeAction.php
+++ b/app/Http/Controllers/HomeAction.php
@@ -42,14 +42,12 @@ class HomeAction extends Controller
             ->with('pages', Page::byCircle($circle)->take(self::TAKE_COUNT)->with(['usersWhoRead' => function ($query) {
                 $query->where('user_id', Auth::id());
             }])->get())
-            ->with('remaining_pages_count', max(Page::byCircle($circle)->count() - self::TAKE_COUNT, 0))
             ->with('next_schedule', Schedule::startOrder()->notStarted()->first())
             ->with('documents', Document::take(self::TAKE_COUNT)->public()->with('schedule')->get())
             ->with('remaining_documents_count', Auth::check()
                                     ? max(Document::public()->count() - self::TAKE_COUNT, 0)
                                     : 0)
             ->with('forms', Form::byCircle($circle)->take(self::TAKE_COUNT)
-                ->public()->open()->withoutCustomForms()->closeOrder()->get())
-            ->with('remaining_forms_count', max(Form::public()->open()->count() - self::TAKE_COUNT, 0));
+                ->public()->open()->withoutCustomForms()->closeOrder()->get());
     }
 }

--- a/app/Http/Controllers/HomeAction.php
+++ b/app/Http/Controllers/HomeAction.php
@@ -44,9 +44,6 @@ class HomeAction extends Controller
             }])->get())
             ->with('next_schedule', Schedule::startOrder()->notStarted()->first())
             ->with('documents', Document::take(self::TAKE_COUNT)->public()->with('schedule')->get())
-            ->with('remaining_documents_count', Auth::check()
-                                    ? max(Document::public()->count() - self::TAKE_COUNT, 0)
-                                    : 0)
             ->with('forms', Form::byCircle($circle)->take(self::TAKE_COUNT)
                 ->public()->open()->withoutCustomForms()->closeOrder()->get());
     }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -205,11 +205,9 @@
                         @summary($page->body)
                     </list-view-item>
                 @endforeach
-                @if ($remaining_pages_count > 0)
-                    <list-view-action-btn href="{{ route('pages.index') }} ">
-                        残り {{ $remaining_pages_count }} 件のお知らせを見る
-                    </list-view-action-btn>
-                @endif
+                <list-view-action-btn href="{{ route('pages.index') }} ">
+                    他のお知らせを見る
+                </list-view-action-btn>
             </list-view>
         @endif
 
@@ -243,11 +241,9 @@
                         {{ $document->description }}
                     </list-view-item>
                 @endforeach
-                @if ($remaining_documents_count > 0)
-                    <list-view-action-btn href="{{ route('documents.index') }} ">
-                        残り {{ $remaining_documents_count }} 件の配布資料を見る
-                    </list-view-action-btn>
-                @endif
+                <list-view-action-btn href="{{ route('documents.index') }} ">
+                    他の配布資料を見る
+                </list-view-action-btn>
             </list-view>
         @endif
 
@@ -273,11 +269,9 @@
                         @summary($form->description)
                     </list-view-item>
                 @endforeach
-                @if ($remaining_forms_count > 0)
-                    <list-view-action-btn href="{{ route('forms.index') }} ">
-                        残り {{ $remaining_forms_count }} 件の受付中の申請を見る
-                    </list-view-action-btn>
-                @endif
+                <list-view-action-btn href="{{ route('forms.index') }} "></list-view-action-btn>
+                    他の受付中の申請を見る
+                </list-view-action-btn>
             </list-view>
         @endif
     </app-container>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -205,7 +205,7 @@
                         @summary($page->body)
                     </list-view-item>
                 @endforeach
-                <list-view-action-btn href="{{ route('pages.index') }} ">
+                <list-view-action-btn href="{{ route('pages.index') }}">
                     他のお知らせを見る
                 </list-view-action-btn>
             </list-view>
@@ -241,7 +241,7 @@
                         {{ $document->description }}
                     </list-view-item>
                 @endforeach
-                <list-view-action-btn href="{{ route('documents.index') }} ">
+                <list-view-action-btn href="{{ route('documents.index') }}">
                     他の配布資料を見る
                 </list-view-action-btn>
             </list-view>
@@ -269,7 +269,7 @@
                         @summary($form->description)
                     </list-view-item>
                 @endforeach
-                <list-view-action-btn href="{{ route('forms.index') }} "></list-view-action-btn>
+                <list-view-action-btn href="{{ route('forms.index') }}">
                     他の受付中の申請を見る
                 </list-view-action-btn>
             </list-view>


### PR DESCRIPTION
## 実装内容
close #341 
<!-- どんな実装をしたのか -->
- そーじさんが行っていた修正を「申請」にも行いました。
- 一斉送信時、`ByTags()` でユーザーが重複しないようにしました。
- 「残り n 件のお知らせを見る」を「他のお知らせを見る」に変更しました。

## 懸念点
- ホームの「他のお知らせを見る」が5件以下のときにも表示されてしまう。

## レビュワーに見て欲しい点
- 重複して表示されないこと
- お知らせ一斉送信時に同じユーザーに何度も送信されないこと

## 参考URL
