### PR TITLE
【企画】企画を削除したら関連テーブルからも削除する #309

### DIFF
--- a/app/Http/Controllers/Circles/DestroyAction.php
+++ b/app/Http/Controllers/Circles/DestroyAction.php
@@ -21,14 +21,10 @@ class DestroyAction extends Controller
             abort(403);
         }
 
-        return DB::transaction(function () use ($circle) {
-            $circle->users()->detach();
-            $circle->answers()->delete();
-            $circle->delete();
+        $circle->delete();
 
-            return redirect()
-                ->route('home')
-                ->with('topAlert.title', '企画参加登録を削除しました');
-        });
+        return redirect()
+            ->route('home')
+            ->with('topAlert.title', '企画参加登録を削除しました');
     }
 }

--- a/app/Http/Controllers/Staff/Circles/DestroyAction.php
+++ b/app/Http/Controllers/Staff/Circles/DestroyAction.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Circles;
+
+use App\Eloquents\Circle;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class DestroyAction extends Controller
+{
+    public function __invoke(Circle $circle)
+    {
+        $circle->delete();
+        return redirect(route('staff.circles.index'));
+    }
+}

--- a/database/migrations/2021_03_09_232637_add_foreign_keys_in_circles.php
+++ b/database/migrations/2021_03_09_232637_add_foreign_keys_in_circles.php
@@ -1,0 +1,85 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeysInCircles extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('circles', function (Blueprint $table) {
+            $table->bigIncrements('id')->change();
+        });
+
+        Schema::table('answers', function (Blueprint $table) {
+            $table->foreign('circle_id')
+                ->references('id')->on('circles')
+                ->onDelete('cascade');
+        });
+
+        Schema::table('booths', function (Blueprint $table) {
+            $table->unsignedBigInteger('circle_id')->change();
+            $table->foreign('circle_id')
+                ->references('id')->on('circles')
+                ->onDelete('cascade');
+        });
+
+        Schema::table('circle_user', function (Blueprint $table) {
+            $table->unsignedBigInteger('circle_id')->change();
+            $table->foreign('circle_id')
+                ->references('id')->on('circles')
+                ->onDelete('cascade');
+        });
+
+        Schema::table('circle_tag', function (Blueprint $table) {
+            $table->foreign('circle_id')
+                ->references('id')->on('circles')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('answers', function (Blueprint $table) {
+            $table->dropForeign(['circle_id']);
+        });
+
+        Schema::table('booths', function (Blueprint $table) {
+            $table->dropForeign(['circle_id']);
+            // $table->integer('circle_id')->change();
+        });
+
+        Schema::table('circle_user', function (Blueprint $table) {
+            $table->dropForeign(['circle_id']);
+            // $table->integer('circle_id')->change();
+        });
+
+        Schema::table('circle_tag', function (Blueprint $table) {
+            $table->dropForeign(['circle_id']);
+        });
+
+        Schema::table('circles', function (Blueprint $table) {
+            $table->increments('id')->change();
+        });
+
+        // L58-66 と一緒に書くとエラーになるので別にした
+        Schema::table('booths', function (Blueprint $table) {
+            $table->integer('circle_id')->change();
+        });
+
+        Schema::table('circle_user', function (Blueprint $table) {
+            $table->integer('circle_id')->change();
+        });
+    }
+}

--- a/database/migrations/2021_03_09_234725_add_foreign_keys_in_answers.php
+++ b/database/migrations/2021_03_09_234725_add_foreign_keys_in_answers.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeysInAnswers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('answer_details', function (Blueprint $table) {
+            $table->foreign('answer_id')
+                ->references('id')->on('answers')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('answer_details', function (Blueprint $table) {
+            $table->dropForeign(['answer_id']);
+        });
+    }
+}

--- a/resources/views/staff/circles/index.blade.php
+++ b/resources/views/staff/circles/index.blade.php
@@ -83,9 +83,21 @@
             </a>
         </template>
         <template v-slot:activities="{ row }">
-            <a v-bind:href="`{{ route('staff.circles.edit', ['circle' => '%%CIRCLE%%']) }}`.replace('%%CIRCLE%%', row['id'])" title="編集" class="btn is-primary is-no-shadow">
-                <i class="fas fa-pencil-alt fa-fw"></i>
-            </a>
+            <form-with-confirm
+                v-bind:action="`{{ route('staff.circles.destroy', ['circle' => '%%CIRCLE%%']) }}`.replace('%%CIRCLE%%', row['id'])" method="post"
+                v-bind:confirm-message="`企画「${row['name']}」を削除しますか？
+
+• 「${row['name']}」が送信した申請の回答はすべて削除されます。`"
+            >
+                @method('delete')
+                @csrf
+                <a v-bind:href="`{{ route('staff.circles.edit', ['circle' => '%%CIRCLE%%']) }}`.replace('%%CIRCLE%%', row['id'])" title="編集" class="btn is-primary is-no-shadow">
+                    <i class="fas fa-pencil-alt fa-fw"></i>
+                </a>
+                <button type="submit" title="削除" class="btn is-danger is-no-shadow">
+                    <i class="fas fa-trash fa-fw"></i>
+                </button>
+            </form-with-confirm>
         </template>
         <template v-slot:td="{ row, keyName }">
             <template v-if="keyName === 'places'">

--- a/routes/staff.php
+++ b/routes/staff.php
@@ -117,6 +117,8 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
 
                 // 企画情報エクスポート
                 Route::get('/export', 'Staff\Circles\ExportAction')->name('export');
+
+                Route::delete('/{circle}', 'Staff\Circles\DestroyAction')->name('destroy');
             });
 
         Route::prefix('/tags')

--- a/tests/Feature/Http/Controllers/Staff/Circles/DestroyActionTest.php
+++ b/tests/Feature/Http/Controllers/Staff/Circles/DestroyActionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Staff\Circles;
+
+use App\Eloquents\Answer;
+use App\Eloquents\Circle;
+use App\Eloquents\Form;
+use App\Eloquents\Place;
+use App\Eloquents\Tag;
+use App\Eloquents\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class DestroyActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private $staff;
+    private $user;
+    private $circle;
+    private $place;
+    private $form;
+    private $answer;
+    private $tag;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->staff = factory(User::class)->states('staff')->create();
+
+        $this->user = factory(User::class)->create();
+        $this->circle = factory(Circle::class)->create();
+
+        $this->place = factory(Place::class)->create();
+
+        $this->form = factory(Form::class)->create();
+        $this->answer = factory(Answer::class)->create([
+            'form_id' => $this->form->id,
+            'circle_id' => $this->circle->id,
+        ]);
+
+        $this->tag = factory(Tag::class)->create();
+
+        $this->user->circles()->attach($this->circle->id, ['is_leader' => true]);
+        $this->circle->places()->attach($this->place->id);
+        $this->circle->tags()->attach($this->tag->id);
+    }
+
+    /**
+     * @test
+     */
+    public function 企画を削除すると関連する情報も削除される()
+    {
+        $responce = $this->actingAs($this->staff)
+            ->withSession(['staff_authorized' => true])
+            ->delete(route('staff.circles.destroy', ['circle' => $this->circle]));
+
+        $responce->assertRedirect(route('staff.circles.index'));
+
+        $this->assertDatabaseMissing('answers', ['form_id' => $this->form->id, 'circle_id' => $this->circle->id]);
+        $this->assertDatabaseMissing('circle_user', ['circle_id' => $this->circle->id]);
+        $this->assertDatabaseMissing('circle_tag', ['circle_id' => $this->circle->id]);
+        $this->assertDatabaseMissing('booths', ['circle_id' => $this->circle->id]);
+    }
+}


### PR DESCRIPTION
## 実装内容
close #309 
<!-- どんな実装をしたのか -->
- answers, booths, circle_user, circle_tag の circle_id に外部キー制約をつけました
- answer_details には answer_id に外部キー制約をつけました
- circle.id を bigIncrements に変更し 外部キー制約 を設定する列の型も変更しました
- 参加登録途中の企画を削除する処理からユーザー紐付けの解除など不要なところを削除しました

## 懸念点

## レビュワーに見て欲しい点
- 削除された企画に関連したデータが削除されること

## 参考URL
