### PR TITLE
【GitHub Actions】リリースZIPには不要なファイルを含めないようにする #10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: composer install --optimize-autoloader --no-dev
         working-directory: dist
       - name: Install JS dependencies
-        run: yarn install
+        run: yarn install --ignore-scripts
         working-directory: dist
       - name: Compile assets
         run: yarn run production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Prepare compile
         # vendor ディレクトリの除外には、最初にスラッシュをつけている。これにより resources フォルダ内にある vendor ディレクトリが除外されてしまうのを防いでいる
         run: |
-          rsync -av --update --delete --stats ./ ./dist/ --exclude='dist/' --exclude='docker_dev/' --exclude='.git/' --exclude='.github/' --exclude='/vendor/' --exclude='node_modules/' --exclude='.circleci/' >& /dev/null
+          rsync -av --update --delete --stats ./ ./dist/ --exclude='dist/' --exclude='docker_dev/' --exclude='.git/' --exclude='.github/' --exclude='/vendor/' --exclude='node_modules/' --exclude='.circleci/' --exclude='tests/' --exclude='.husky/' --exclude='phpunit.xml' --exclude='phpcs.xml' --exclude='.editorconfig' --exclude='.env.testing' --exclude='.eslintrc.js' --exclude='.gitattributes' --exclude='.gitignore' --exclude='.prettierrc' --exclude='.stylelintrc.js' >& /dev/null
       - name: Install PHP dependencies
         run: composer install --optimize-autoloader --no-dev
         working-directory: dist


### PR DESCRIPTION
## 実装内容
close #10
<!-- どんな実装をしたのか -->

リリースZIPには、テストファイルなどの不要なファイルを含めないようにしました。

作成されたZIPファイル → https://github.com/portal-dots/PortalDots/releases/tag/untagged-509b3cbc30a0c767653e
(GitHub の portal-dots Organization に所属しているユーザーのみアクセス可能な URL？)

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
