### PR TITLE
【申請】ファイルアップロードの設問不備対応 #559

### DIFF
--- a/resources/js/forms_editor/components/form/QuestionUpload.vue
+++ b/resources/js/forms_editor/components/form/QuestionUpload.vue
@@ -9,7 +9,17 @@
         <p class="form-text text-muted mb-2">
           {{ description }}
         </p>
-        <input type="file" class="form-control" tabindex="-1" />
+        <template v-if="question.allowed_types">
+          <input type="file" class="form-control" tabindex="-1" />
+        </template>
+        <template v-else>
+          <p>
+            <i class="fa fa-exclamation-triangle mr-1"></i>
+            <b
+              >ファイルアップロードを受け付けるには「許可される拡張子」を1つ以上指定してください</b
+            >
+          </p>
+        </template>
       </div>
     </template>
     <template v-slot:edit-panel>

--- a/resources/views/includes/question.blade.php
+++ b/resources/views/includes/question.blade.php
@@ -27,6 +27,9 @@
         v-bind:number-max="{{ $question->number_max ?? 'null' }}"
         v-bind:allowed-types="{{ json_encode($question->allowed_types_array) }}"
         v-bind:disabled="{{ json_encode($is_disabled ?? false) }}"
+        @if ($question->type === 'upload' && empty($question->allowed_types))
+        invalid="この設問は、スタッフによる設定不備があるためファイルをアップロードできません。申し訳ございませんが {{ config('portal.admin_name') }} までお問い合わせください。"
+        @endif
         @error('answers.'. $question->id)
         invalid="{{ $message }}"
         @enderror


### PR DESCRIPTION
## 実装内容
close #559 
<!-- どんな実装をしたのか -->
- フォームエディター上で「許可される拡張子」を指定していない場合に設定するように促すメッセージを表示するようにしました
- 回答画面で「許可される拡張子」がセットされていないアップロード設問には常にエラーメッセージを表示するようにしました

↓フォームエディター
![image](https://user-images.githubusercontent.com/8391342/117336426-25c80800-aed7-11eb-96b8-df4834871032.png)

↓回答画面
![image](https://user-images.githubusercontent.com/8391342/117336671-70498480-aed7-11eb-8047-6ba88a126129.png)


## 懸念点

## レビュワーに見て欲しい点

## 参考URL
