### PR TITLE
【Staff/配布資料】配布資料を削除できるようにする #565

### DIFF
--- a/app/Eloquents/Permission.php
+++ b/app/Eloquents/Permission.php
@@ -187,6 +187,12 @@ class Permission extends SpatiePermission
                     '配布資料(全機能)',
                     '配布資料管理の全機能を利用可能。セキュリティのため、この権限を割り当てるユーザーは最小限にしてください。'
                 ),
+                'staff.documents.read,edit,delete' => new PermissionInfo(
+                    'staff.documents.read,edit,delete',
+                    'スタッフモード › 配布資料管理 › 閲覧と編集、削除',
+                    '配布資料(削除)',
+                    '配布資料の閲覧と編集、作成、削除が可能'
+                ),
                 'staff.documents.read,edit' => new PermissionInfo(
                     'staff.documents.read,edit',
                     'スタッフモード › 配布資料管理 › 閲覧と編集',

--- a/app/Http/Controllers/Staff/Documents/DestroyAction.php
+++ b/app/Http/Controllers/Staff/Documents/DestroyAction.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Staff\Documents;
+
+use App\Eloquents\Document;
+use App\Services\Documents\DocumentsService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class DestroyAction extends Controller
+{
+    /**
+     * @var DocumentsService
+     */
+    private $documentsService;
+
+    public function __construct(DocumentsService $documentsService)
+    {
+        $this->documentsService = $documentsService;
+    }
+
+    public function __invoke(Document $document)
+    {
+        $this->documentsService->deleteDocument($document);
+
+        return redirect()
+            ->route('staff.documents.index')
+            ->with('topAlert.title', '配布資料を削除しました');
+    }
+}

--- a/app/Services/Documents/DocumentsService.php
+++ b/app/Services/Documents/DocumentsService.php
@@ -78,6 +78,10 @@ class DocumentsService
         ?Schedule $schedule,
         ?string $notes
     ): bool {
+        if (!empty($file)) {
+            Storage::delete($document->path);
+        }
+
         return $document->update([
             'name' => $name,
             'description' => $description,

--- a/app/Services/Documents/DocumentsService.php
+++ b/app/Services/Documents/DocumentsService.php
@@ -8,6 +8,7 @@ use App\Eloquents\Document;
 use App\Eloquents\User;
 use App\Eloquents\Schedule;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 class DocumentsService
 {
@@ -89,5 +90,18 @@ class DocumentsService
             'schedule_id' => !empty($schedule) ? $schedule->id : null,
             'notes' => $notes,
         ]);
+    }
+
+    /**
+     * 配布資料を削除する
+     *
+     * @param Document $document
+     *
+     * @return bool
+     */
+    public function deleteDocument(Document $document): bool
+    {
+        Storage::delete($document->path);
+        return $document->delete();
     }
 }

--- a/resources/views/staff/documents/index.blade.php
+++ b/resources/views/staff/documents/index.blade.php
@@ -81,9 +81,20 @@
             </a>
         </template>
         <template v-slot:activities="{ row }">
-            <icon-button v-bind:href="`{{ route('staff.documents.edit', ['document' => '%%DOCUMENT%%']) }}`.replace('%%DOCUMENT%%', row['id'])" title="編集">
-                <i class="fas fa-pencil-alt fa-fw"></i>
-            </icon-button>
+            <form-with-confirm
+                v-bind:action="`{{ route('staff.documents.destroy', ['document' => '%%DOCUMENT%%']) }}`.replace('%%DOCUMENT%%', row['id'])"
+                method="post"
+                v-bind:confirm-message="`配布資料「${row['name']}」を削除しますか？`"
+            >
+                @method('delete')
+                @csrf
+                <icon-button v-bind:href="`{{ route('staff.documents.edit', ['document' => '%%DOCUMENT%%']) }}`.replace('%%DOCUMENT%%', row['id'])" title="編集">
+                    <i class="fas fa-pencil-alt fa-fw"></i>
+                </icon-button>
+                <icon-button submit title="削除">
+                    <i class="fas fa-trash fa-fw"></i>
+                </icon-button>
+            </form-with-confirm>
         </template>
         <template v-slot:td="{ row, keyName }">
             <template v-if="keyName === 'path'">

--- a/routes/staff.php
+++ b/routes/staff.php
@@ -226,7 +226,7 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
                 Route::get('/{document}/edit', 'Staff\Documents\EditAction')->name('edit')->middleware(['can:staff.documents.edit']);
                 Route::patch('/{document}', 'Staff\Documents\UpdateAction')->name('update')->middleware(['can:staff.documents.edit']);
                 Route::get('/{document}', 'Staff\Documents\ShowAction')->name('show')->middleware(['can:staff.documents.read']);
-                Route::delete('/{document}', 'Staff\Documents\DestroyAction')->name('destroy');
+                Route::delete('/{document}', 'Staff\Documents\DestroyAction')->name('destroy')->middleware(['can:staff.documents.delete']);
             });
 
         // スタッフの権限設定

--- a/routes/staff.php
+++ b/routes/staff.php
@@ -226,6 +226,7 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
                 Route::get('/{document}/edit', 'Staff\Documents\EditAction')->name('edit')->middleware(['can:staff.documents.edit']);
                 Route::patch('/{document}', 'Staff\Documents\UpdateAction')->name('update')->middleware(['can:staff.documents.edit']);
                 Route::get('/{document}', 'Staff\Documents\ShowAction')->name('show')->middleware(['can:staff.documents.read']);
+                Route::delete('/{document}', 'Staff\Documents\DestroyAction')->name('destroy');
             });
 
         // スタッフの権限設定

--- a/tests/Feature/CheckPermissionsTest.php
+++ b/tests/Feature/CheckPermissionsTest.php
@@ -56,6 +56,7 @@ class CheckPermissionsTest extends TestCase
             'staff.pages.read,export',
             'staff.pages.read',
             'staff.documents',
+            'staff.documents.read,edit,delete',
             'staff.documents.read,edit',
             'staff.documents.read,export',
             'staff.documents.read',

--- a/tests/Feature/Http/Controllers/Staff/Documents/DestroyActionTest.php
+++ b/tests/Feature/Http/Controllers/Staff/Documents/DestroyActionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Staff\Documents;
+
+use App\Eloquents\Document;
+use App\Eloquents\Permission;
+use App\Eloquents\User;
+use App\Services\Documents\DocumentsService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Mockery;
+use Tests\TestCase;
+
+class DestroyActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @var User
+     */
+    private $staff;
+
+    /**
+     * @var Document
+     */
+    private $document;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->staff = factory(User::class)->states('staff')->create();
+        $this->document = factory(Document::class)->create();
+    }
+
+    /**
+     * @test
+     */
+    public function DocumentsServiceのdeleteDocumentが呼び出される()
+    {
+        Permission::create(['name' => 'staff.documents.delete']);
+        $this->staff->syncPermissions(['staff.documents.delete']);
+
+        $this->mock(DocumentsService::class, function ($mock) {
+            $mock->shouldReceive('deleteDocument')->once()->with(
+                Mockery::on(function ($arg) {
+                    return $arg->id === $this->document->id;
+                })
+            )->andReturn(true);
+        });
+
+        $response = $this->actingAs($this->staff)
+                        ->withSession(['staff_authorized' => true])
+                        ->delete(route('staff.documents.destroy', ['document' => $this->document]));
+
+        $response->assertSessionHasNoErrors();
+        $response->assertRedirect(route('staff.documents.index'));
+    }
+
+    /**
+     * @test
+     */
+    public function 権限がない場合は配布資料を削除できない()
+    {
+        $response = $this->actingAs($this->staff)
+                        ->withSession(['staff_authorized' => true])
+                        ->delete(route('staff.documents.destroy', ['document' => $this->document]));
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Feature/Services/Documents/DocumentsServiceTest.php
+++ b/tests/Feature/Services/Documents/DocumentsServiceTest.php
@@ -120,12 +120,14 @@ class DocumentsServiceTest extends TestCase
      */
     public function updateDocument_ファイルのアップデートができる()
     {
+        Storage::fake('local');
         $schedule = factory(Schedule::class)->create();
+        $oldFile = UploadedFile::fake()->create('第２回.pdf', 1, 'application/pdf');
 
         $document = $this->documentsService->createDocument(
             '第２回会議資料',
             '第２回会議にて配布した資料のPDFバージョンです',
-            UploadedFile::fake()->create('第２回.pdf', 1, 'application/pdf'),
+            $oldFile,
             $this->staff,
             true,
             false,
@@ -144,6 +146,8 @@ class DocumentsServiceTest extends TestCase
             null,
             'updated notes'
         );
+
+        Storage::disk('local')->assertMissing("document/{$oldFile->hashName()}");
 
         $this->assertDatabaseHas('documents', [
             'name' => 'updated filename',

--- a/tests/Feature/Services/Documents/DocumentsServiceTest.php
+++ b/tests/Feature/Services/Documents/DocumentsServiceTest.php
@@ -157,4 +157,34 @@ class DocumentsServiceTest extends TestCase
             'notes' => 'updated notes'
         ]);
     }
+
+    /**
+     * @test
+     */
+    public function deleteDocument_ファイルの削除ができる()
+    {
+        Storage::fake('local');
+        $file = UploadedFile::fake()->create('削除されちゃう.pdf', 1, 'application/pdf');
+
+        $document = $this->documentsService->createDocument(
+            '削除される資料',
+            '削除される資料です。悲しいね。',
+            $file,
+            $this->staff,
+            true,
+            false,
+            null,
+            'ドロン'
+        );
+
+        Storage::disk('local')->assertExists("documents/{$file->hashName()}");
+
+        $this->documentsService->deleteDocument($document);
+
+        Storage::disk('local')->assertMissing("documents/{$file->hashName()}");
+        $this->assertDatabaseMissing('documents', [
+            'id' => $document->id,
+            'name' => '削除される資料です'
+        ]);
+    }
 }


### PR DESCRIPTION
## 実装内容
close #565 
<!-- どんな実装をしたのか -->
- 配布資料の削除機能を作成しました。対応する権限の作成も行いました。
- 配布資料を削除するときにファイルも削除するようにしました。
- 配布資料の更新時に古いファイルを削除するようにしました。

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
