### PR TITLE
【企画参加登録/招待】招待を受ける側の表示や処理を修正 #606 #607

### DIFF
--- a/app/Http/Controllers/Circles/ShowAction.php
+++ b/app/Http/Controllers/Circles/ShowAction.php
@@ -15,7 +15,10 @@ class ShowAction extends Controller
 
         $reauthorized_at = new CarbonImmutable(session()->get('user_reauthorized_at'));
 
-        if (session()->has('user_reauthorized_at') && $reauthorized_at->addHours(2)->gte(now())) {
+        if (
+            !$circle->hasSubmitted()
+            || (session()->has('user_reauthorized_at') && $reauthorized_at->addHours(2)->gte(now()))
+        ) {
             $circle->load('users', 'places');
 
             return view('circles.show')

--- a/resources/views/circles/users/invite.blade.php
+++ b/resources/views/circles/users/invite.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.no_drawer')
 
+@section('no_circle_selector', true)
+
 @section('title', '企画参加登録')
 
 @section('content')

--- a/tests/Feature/Http/Controllers/Circles/ShowActionTest.php
+++ b/tests/Feature/Http/Controllers/Circles/ShowActionTest.php
@@ -16,9 +16,25 @@ class ShowActionTest extends BaseTestCase
 {
     use RefreshDatabase;
 
+    /**
+     * @var User
+     */
     private $user;
+
+    /**
+     * @var User
+     */
     private $mamber;
+
+    /**
+     * @var Circle
+     */
     private $circle;
+
+    /**
+     * @var Circle
+     */
+    private $notSubmittedCircle;
 
     public function setUp(): void
     {
@@ -26,9 +42,16 @@ class ShowActionTest extends BaseTestCase
 
         $this->user = factory(User::class)->create();
         $this->member = factory(User::class)->create();
-        $this->circle = factory(Circle::class)->states('notSubmitted')->create();
+        $this->circle = factory(Circle::class)->create();
+
+        $this->notSubmittedCircle = factory(Circle::class)->states('notSubmitted')->create();
 
         $this->circle->users()->attach([
+            $this->user->id => ['is_leader' => true],
+            $this->member->id => ['is_leader' => false],
+        ]);
+
+        $this->notSubmittedCircle->users()->attach([
             $this->user->id => ['is_leader' => true],
             $this->member->id => ['is_leader' => false],
         ]);
@@ -41,18 +64,17 @@ class ShowActionTest extends BaseTestCase
     /**
      * @test
      */
-    public function 未認証ユーザーには認証ページを表示()
+    public function 提出済み企画の場合で未認証ユーザーには認証ページを表示する()
     {
-        $responce = $this
-                    ->actingAs($this->user)
+        $response = $this->actingAs($this->user)
                     ->get(
                         route('circles.show', [
                             'circle' => $this->circle,
                         ])
                     );
 
-        $responce->assertStatus(302);
-        $responce->assertRedirect(
+        $response->assertStatus(302);
+        $response->assertRedirect(
             route('circles.auth', [
                 'circle' => $this->circle
             ])
@@ -62,9 +84,24 @@ class ShowActionTest extends BaseTestCase
     /**
      * @test
      */
+    public function 未提出の企画の場合は認証画面を表示しない()
+    {
+        $response = $this->actingAs($this->user)
+                        ->get(
+                            route('circles.show', [
+                                'circle' => $this->notSubmittedCircle,
+                            ])
+                        );
+
+        $response->assertOk();
+    }
+
+    /**
+     * @test
+     */
     public function メンバーは企画の詳細を表示できる()
     {
-        $responce = $this
+        $response = $this
                     ->actingAs($this->user)
                     ->withSession(['user_reauthorized_at' => now()])
                     ->get(
@@ -73,7 +110,7 @@ class ShowActionTest extends BaseTestCase
                         ])
                     );
 
-        $responce->assertOk();
+        $response->assertOk();
     }
 
     /**
@@ -81,17 +118,16 @@ class ShowActionTest extends BaseTestCase
      */
     public function 未提出の場合副責任者は削除ボタンが表示される()
     {
-        $responce = $this
+        $response = $this
                     ->actingAs($this->member)
-                    ->withSession(['user_reauthorized_at' => now()])
                     ->get(
                         route('circles.show', [
-                            'circle' => $this->circle,
+                            'circle' => $this->notSubmittedCircle,
                         ])
                     );
 
-        $responce->assertOk();
-        $responce->assertSee('この企画から抜ける');
+        $response->assertOk();
+        $response->assertSee('この企画から抜ける');
     }
 
     /**
@@ -102,7 +138,7 @@ class ShowActionTest extends BaseTestCase
         $this->circle->submitted_at = now();
         $this->circle->save();
 
-        $responce = $this
+        $response = $this
                     ->actingAs($this->member)
                     ->withSession(['user_reauthorized_at' => now()])
                     ->get(
@@ -111,8 +147,8 @@ class ShowActionTest extends BaseTestCase
                         ])
                     );
 
-        $responce->assertOk();
-        $responce->assertDontSee('この企画から抜ける');
+        $response->assertOk();
+        $response->assertDontSee('この企画から抜ける');
     }
 
     /**
@@ -120,17 +156,16 @@ class ShowActionTest extends BaseTestCase
      */
     public function 責任者には削除ボタンを表示しない()
     {
-        $responce = $this
+        $response = $this
                     ->actingAs($this->user)
-                    ->withSession(['user_reauthorized_at' => now()])
                     ->get(
                         route('circles.show', [
-                            'circle' => $this->circle,
+                            'circle' => $this->notSubmittedCircle,
                         ])
                     );
 
-        $responce->assertOk();
-        $responce->assertDontSee('この企画から抜ける');
+        $response->assertOk();
+        $response->assertDontSee('この企画から抜ける');
     }
 
     /**
@@ -140,7 +175,7 @@ class ShowActionTest extends BaseTestCase
     {
         $anotherUser = factory(User::class)->create();
 
-        $responce = $this
+        $response = $this
                     ->actingAs($anotherUser)
                     ->withSession(['user_reauthorized_at' => now()])
                     ->get(
@@ -149,7 +184,7 @@ class ShowActionTest extends BaseTestCase
                         ])
                     );
 
-        $responce->assertStatus(403);
+        $response->assertStatus(403);
     }
 
     /**
@@ -165,7 +200,7 @@ class ShowActionTest extends BaseTestCase
             'updated_by' => 1,
             ]);
 
-        $responce = $this
+        $response = $this
                     ->actingAs($this->user)
                     ->withSession(['user_reauthorized_at' => now()])
                     ->get(
@@ -173,9 +208,9 @@ class ShowActionTest extends BaseTestCase
                             'circle' => $this->circle,
                         ])
                     );
-        $responce->assertOk();
-        $responce->assertSee('使用場所');
-        $responce->assertSee($place->name);
+        $response->assertOk();
+        $response->assertSee('使用場所');
+        $response->assertSee($place->name);
     }
 
     /**
@@ -183,7 +218,7 @@ class ShowActionTest extends BaseTestCase
      */
     public function 場所が登録されていないときは使用場所を表示しない()
     {
-        $responce = $this
+        $response = $this
                     ->actingAs($this->user)
                     ->withSession(['user_reauthorized_at' => now()])
                     ->get(
@@ -191,7 +226,7 @@ class ShowActionTest extends BaseTestCase
                             'circle' => $this->circle,
                         ])
                     );
-        $responce->assertOk();
-        $responce->assertDontSee('使用場所');
+        $response->assertOk();
+        $response->assertDontSee('使用場所');
     }
 }


### PR DESCRIPTION
## 実装内容
close #606 
close #607 
<!-- どんな実装をしたのか -->
- 招待を受ける側の画面から企画セレクターを削除しました #606 
- 認証画面は未提出の企画には表示しないようにしました #607 
  - この修正で企画詳細に「〇〇の副責任者になりました」と表示されるようになりました

## 懸念点

## レビュワーに見て欲しい点
- 招待が問題なく受けられること
- 招待を受け入れたときに認証画面が表示されないこと

## 参考URL
