### PR TITLE
開発環境としてPortalDotsをセットアップした場合もインストーラーが起動してしまう問題を修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NOT_INSTALLED=true
+APP_NOT_INSTALLED=false
 APP_NAME=PortalDots
 APP_ENV=local
 APP_KEY=


### PR DESCRIPTION
## 実装内容
<!-- どんな実装をしたのか -->

[README](https://github.com/portal-dots/PortalDots) に記載の方法で開発環境をセットアップした後 localhost にアクセスするとインストーラーが起動してしまう問題を修正しました。

具体的には、 `.env.example` の `APP_NOT_INSTALLED` を false に変更しました。

## 懸念点

## レビュワーに見て欲しい点

## 参考URL
