### PR TITLE
Appleシリコン搭載MacでPortalDots開発環境を起動できない問題を修正

### DIFF
--- a/docker_dev/docker-compose.yml
+++ b/docker_dev/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   web:
     container_name: portal_web
+    platform: linux/amd64
     build: ./web
     ports:
       - 80:80
@@ -12,6 +13,7 @@ services:
 
   db:
     image: mysql:5.7
+    platform: linux/amd64
     container_name: portal_db
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -28,6 +30,7 @@ services:
 
   db-testing:
     image: mysql:5.7
+    platform: linux/amd64
     container_name: portal_db_testing
     environment:
       MYSQL_ROOT_PASSWORD: root
@@ -46,6 +49,7 @@ services:
   phpmyadmin:
     container_name: portal_phpmyadmin
     image: phpmyadmin/phpmyadmin
+    platform: linux/amd64
     environment:
       - PMA_ARBITRARY=1
       - PMA_HOSTS=portal_db
@@ -57,6 +61,7 @@ services:
   mailhog:
     container_name: portal_mailhog
     image: mailhog/mailhog
+    platform: linux/amd64
     ports:
       - 1025:1025
       - 8025:8025


### PR DESCRIPTION
## 実装内容
`docker-compose.yml` ファイルに `platform: linux/amd64` を追記しました。

## 懸念点

## レビュワーに見て欲しい点
- Mac以外のPCで、正常に開発環境を起動できるかどうか

## 参考URL
