### PR TITLE
スタッフ認証メールの件名で認証コードを表示

### DIFF
--- a/app/Notifications/Auth/StaffAuthNotification.php
+++ b/app/Notifications/Auth/StaffAuthNotification.php
@@ -58,7 +58,7 @@ class StaffAuthNotification extends Notification
     public function toMail($notifiable)
     {
         return (new MailMessage())
-            ->subject('スタッフ認証')
+            ->subject('スタッフ認証 (認証コード : ' . $this->verify_code . ')')
             ->greeting('スタッフ認証')
             ->line($this->user->name . ' 様')
             ->line('スタッフモードにアクセスするには、以下の「認証コード」をスタッフ認証ページで入力してください。')


### PR DESCRIPTION
## 実装内容
<!-- どんな実装をしたのか -->

スタッフモードにアクセスした際に送信されるスタッフ認証メールの件名に、認証コードを表示するようにしました。

これにより、認証メールの本文を開かなくても認証コードがわかるようになります。

![image](https://user-images.githubusercontent.com/6687653/139582712-53daacf0-4642-42a4-955a-dd380aeec852.png)


## 懸念点

## レビュワーに見て欲しい点
- メール送信時にエラーが生じないか

## 参考URL
