### PR TITLE
【スタッフ認証】スタッフ認証後、アクセスされたページに戻る #642

### DIFF
--- a/app/Http/Controllers/Staff/Verify/VerifyAction.php
+++ b/app/Http/Controllers/Staff/Verify/VerifyAction.php
@@ -21,6 +21,7 @@ class VerifyAction extends Controller
 
     public function __invoke(Request $request)
     {
+        $previous_url = $this->staffAuthService->getPreviousUrl();
         $result = $this->staffAuthService->verifyAndAuthenticate(Auth::user(), $request->verify_code);
 
         if (!$result) {
@@ -28,10 +29,8 @@ class VerifyAction extends Controller
                 ->withErrors(['verify_code' => '認証コードが間違っているか、期限切れです。再度お試しください。']);
         }
 
-        $previous_url = $request->session()->get('staff_auth_previous_url');
         if (!empty($previous_url)) {
-            $redirect_to = filter_var($previous_url, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED);
-            return redirect($redirect_to);
+            return redirect($previous_url);
         }
         return redirect()->route('staff.index');
     }

--- a/app/Http/Controllers/Staff/Verify/VerifyAction.php
+++ b/app/Http/Controllers/Staff/Verify/VerifyAction.php
@@ -28,6 +28,11 @@ class VerifyAction extends Controller
                 ->withErrors(['verify_code' => '認証コードが間違っているか、期限切れです。再度お試しください。']);
         }
 
+        $previous_url = $request->session()->get('staff_auth_previous_url');
+        if (!empty($previous_url)) {
+            $redirect_to = filter_var($previous_url, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED);
+            return redirect($redirect_to);
+        }
         return redirect()->route('staff.index');
     }
 }

--- a/app/Http/Middleware/RedirectIfStaffNotAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfStaffNotAuthenticated.php
@@ -3,10 +3,21 @@
 namespace App\Http\Middleware;
 
 use App\Eloquents\User;
+use App\Services\Auth\StaffAuthService;
 use Closure;
 
 class RedirectIfStaffNotAuthenticated
 {
+    /**
+     * @var StaffAuthService
+     */
+    private $staffAuthService;
+
+    public function __construct(StaffAuthService $staffAuthService)
+    {
+        $this->staffAuthService = $staffAuthService;
+    }
+
     /**
      * Handle an incoming request.
      *
@@ -17,7 +28,7 @@ class RedirectIfStaffNotAuthenticated
     public function handle($request, Closure $next)
     {
         if (!$request->session()->get('staff_authorized') && !config('portal.enable_demo_mode')) {
-            session(['staff_auth_previous_url' => $request->url()]);
+            $this->staffAuthService->setPreviousUrl($request->url());
             return redirect()
                 ->route('staff.verify.index');
         }

--- a/app/Http/Middleware/RedirectIfStaffNotAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfStaffNotAuthenticated.php
@@ -17,6 +17,7 @@ class RedirectIfStaffNotAuthenticated
     public function handle($request, Closure $next)
     {
         if (!$request->session()->get('staff_authorized') && !config('portal.enable_demo_mode')) {
+            session(['staff_auth_previous_url' => $request->url()]);
             return redirect()
                 ->route('staff.verify.index');
         }

--- a/app/Services/Auth/StaffAuthService.php
+++ b/app/Services/Auth/StaffAuthService.php
@@ -22,6 +22,8 @@ final class StaffAuthService
 
     public const SESSION_KEY_STAFF_AUTHORIZED = 'staff_authorized';
 
+    public const SESSION_KEY_PREVIOUS_URL = 'staff_auth_service__previous_url';
+
     /**
      * ユーザーへスタッフ認証のためのメールを送信
      *
@@ -80,6 +82,29 @@ final class StaffAuthService
     }
 
     /**
+     * スタッフ認証画面にアクセスする前にアクセスしたURLをセッションに保存
+     *
+     * @param string $url
+     * @return void
+     */
+    public function setPreviousUrl(string $url)
+    {
+        session([self::SESSION_KEY_PREVIOUS_URL => $url]);
+    }
+
+    /**
+     * スタッフ認証画面にアクセスする前にアクセスしたURLを取得
+     *
+     * @return string|null
+     */
+    public function getPreviousUrl(): ?string
+    {
+        $url = session(self::SESSION_KEY_PREVIOUS_URL, null);
+        $filtered_url = filter_var($url, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED);
+        return !empty($filtered_url) ? $filtered_url : null;
+    }
+
+    /**
      * StaffAuthService で扱うセッションを全てリセット
      *
      * @return void
@@ -91,6 +116,7 @@ final class StaffAuthService
             self::SESSION_KEY_STAFF_AUTHORIZED => null,
             self::SESSION_KEY_USER_ID => null,
             self::SESSION_KEY_VERIFY_CODE_HASH => null,
+            self::SESSION_KEY_PREVIOUS_URL => null,
         ]);
     }
 }


### PR DESCRIPTION
## 実装内容
close #642
<!-- どんな実装をしたのか -->

- スタッフ認証後、スタッフ認証画面が表示される前にアクセスしようとしていたページへリダイレクトされるようにしました。

## 懸念点

## レビュワーに見て欲しい点
- どんな場合でもスタッフ認証後に意図したページへリダイレクトされるかどうか

## 参考URL
