### PR TITLE
【インストーラー】「PortalDots から配信されるメールの差出人メールアドレス」にメールアドレス以外を入力するとサーバーエラーが表示される #651

### DIFF
--- a/app/Services/Install/MailService.php
+++ b/app/Services/Install/MailService.php
@@ -30,7 +30,7 @@ class MailService extends AbstractService
             'MAIL_PORT' => ['required'],
             'MAIL_USERNAME' => ['required'],
             'MAIL_PASSWORD' => ['required'],
-            'MAIL_FROM_ADDRESS' => ['required'],
+            'MAIL_FROM_ADDRESS' => ['required', 'email'],
             'MAIL_FROM_NAME' => ['required'],
         ];
     }


### PR DESCRIPTION
## 実装内容
close #651
<!-- どんな実装をしたのか -->

- インストーラー内の「PortalDots から配信されるメールの差出人メールアドレス」入力欄に、メールアドレスではない文字列を入力した場合に、正しくバリデーションエラーが表示されるようにしました。

<img width="832" alt="image" src="https://user-images.githubusercontent.com/6687653/143015480-ce914b57-fefb-487e-8e06-205bb466dfb4.png">


## 懸念点

## レビュワーに見て欲しい点

## 参考URL
