### PR TITLE
ダークモード対応の微調整

### DIFF
--- a/app/Services/Utils/UIThemeService.php
+++ b/app/Services/Utils/UIThemeService.php
@@ -45,6 +45,7 @@ class UIThemeService
         }
     }
 
+    // このメソッドのロジックを変更した場合、 UiPrimaryColorPicker にあるロジックも修正する必要がある
     public static function getCssPrimaryColor(float $alpha = 1, bool $isDark = false): string
     {
         $hsl = config('portal.primary_color_hsl');

--- a/resources/js/v2/components/UiPrimaryColorPicker.vue
+++ b/resources/js/v2/components/UiPrimaryColorPicker.vue
@@ -45,7 +45,7 @@
 <script>
 import convert from 'color-convert'
 
-const rootElement = document.documentElement
+const bodyElement = document.body
 
 export default {
   props: {
@@ -76,10 +76,10 @@ export default {
     this.hexValue = this.convertHslaToHex(this.defaultHslaValue)
   },
   destroyed() {
-    rootElement.style.removeProperty('--color-primary')
-    rootElement.style.removeProperty('--color-focus-primary')
-    rootElement.style.removeProperty('--color-primary-hover')
-    rootElement.style.removeProperty('--color-primary-inverse-hover')
+    bodyElement.style.removeProperty('--color-primary')
+    bodyElement.style.removeProperty('--color-focus-primary')
+    bodyElement.style.removeProperty('--color-primary-hover')
+    bodyElement.style.removeProperty('--color-primary-inverse-hover')
   },
   computed: {
     hslValue() {
@@ -109,19 +109,19 @@ export default {
     hexValue(value) {
       this.waitForReset = false
       const hsl = this.convertHexToHsl(value)
-      rootElement.style.setProperty(
+      bodyElement.style.setProperty(
         '--color-primary',
         `hsla(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%, 1)`
       )
-      rootElement.style.setProperty(
+      bodyElement.style.setProperty(
         '--color-focus-primary',
         `hsla(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%, 0.25)`
       )
-      rootElement.style.setProperty(
+      bodyElement.style.setProperty(
         '--color-primary-hover',
         `hsla(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%, 0.8)`
       )
-      rootElement.style.setProperty(
+      bodyElement.style.setProperty(
         '--color-primary-inverse-hover',
         `hsla(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%, 0.15)`
       )

--- a/resources/js/v2/components/UiPrimaryColorPicker.vue
+++ b/resources/js/v2/components/UiPrimaryColorPicker.vue
@@ -109,21 +109,38 @@ export default {
     hexValue(value) {
       this.waitForReset = false
       const hsl = this.convertHexToHsl(value)
+      const h = hsl[0]
+      let s = hsl[1]
+      let l = hsl[2]
+      const isDarkTheme =
+        bodyElement.classList.contains('theme-dark') ||
+        (bodyElement.classList.contains('theme-system') &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches)
+
+      if (isDarkTheme) {
+        s = Math.max(s - 10, 0)
+        l = Math.min(l + 20, 100)
+      }
+
       bodyElement.style.setProperty(
         '--color-primary',
-        `hsla(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%, 1)`
+        `hsla(${h}, ${s}%, ${l}%, 1)`
+      )
+      bodyElement.style.setProperty(
+        '--color-primary-light',
+        `hsla(${h}, ${s}%, ${l}%, 0.1)`
       )
       bodyElement.style.setProperty(
         '--color-focus-primary',
-        `hsla(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%, 0.25)`
+        `hsla(${h}, ${s}%, ${l}%, 0.25)`
       )
       bodyElement.style.setProperty(
         '--color-primary-hover',
-        `hsla(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%, 0.8)`
+        `hsla(${h}, ${s}%, ${l}%, 0.8)`
       )
       bodyElement.style.setProperty(
         '--color-primary-inverse-hover',
-        `hsla(${hsl[0]}, ${hsl[1]}%, ${hsl[2]}%, 0.15)`
+        `hsla(${h}, ${s}%, ${l}%, 0.15)`
       )
     }
   }

--- a/resources/views/includes/head_ui_theme.blade.php
+++ b/resources/views/includes/head_ui_theme.blade.php
@@ -2,88 +2,20 @@
 
 <meta name="color-scheme" content="{{ $uiThemeService->getCssColorScheme() }}">
 
-@if (in_array($uiThemeService->getCurrentTheme(), ['light', 'system'], true))
-    <style>
-        :root {
-            /* Primary */
-            color-scheme: {{ $uiThemeService->getCssColorScheme() }};
-            --color-primary: {{ $uiThemeService->getCssPrimaryColor() }};
-            --color-primary-light: {{ $uiThemeService->getCssPrimaryColor(0.1) }};
-            --color-focus-primary: {{ $uiThemeService->getCssPrimaryColor(0.25) }};
-            --color-primary-hover: {{ $uiThemeService->getCssPrimaryColor(0.8) }};
-            --color-primary-inverse-hover: {{ $uiThemeService->getCssPrimaryColor(0.15) }};
-            /* Other */
-            --color-text: rgb(34, 41, 47);
-            --color-danger: rgb(219, 60, 62);
-            --color-danger-light: rgb(219, 60, 62, 0.1);
-            --color-success: rgb(27, 162, 78);
-            --color-muted: rgb(108, 117, 125);
-            --color-muted-2: rgb(167, 182, 194);
-            --color-muted-3: rgb(195, 207, 216);
-            --color-border: rgb(218, 224, 230);
-            --color-bg-base: rgb(243, 244, 250);
-            --color-bg-light: rgb(239, 239, 239);
-            --color-bg-surface: rgb(255, 255, 255);
-            --color-bg-surface-2: rgb(255, 255, 255);
-            --color-bg-surface-3: rgb(255, 255, 255);
-            --color-form-control: rgb(250, 250, 252);
-            --color-form-control-readonly: rgb(255, 255, 255);
-            --color-form-control-focus: rgb(255, 255, 255);
-            --color-box-shadow: rgba(34, 41, 47, 0.5);
-            --color-box-shadow-subdued: rgba(34, 41, 47, 0.03);
-            --color-focus-danger: rgba(219, 60, 62, 0.25);
-            --color-pre-background: rgba(255, 255, 255, 0.25);
-            --color-code-background: rgba(27, 162, 78, 0.1);
-            --color-drawer-backdrop: rgba(34, 41, 47, 0.75);
-            --color-grid-table-stripe: rgba(239, 239, 239, 0.4);
-            --color-top-alert-border: rgba(255, 255, 255, 0.16);
-            --color-danger-hover: rgba(219, 60, 62, 0.8);
-            --color-success-hover: rgba(27, 162, 78, 0.8);
+<style>
+    body.theme-light,
+    body.theme-system {
+        @include('includes.head_ui_theme_light')
+    }
+
+    body.theme-dark {
+        @include('includes.head_ui_theme_dark')
+    }
+
+    @media (prefers-color-scheme: dark) {
+        body.theme-system {
+            @include('includes.head_ui_theme_dark')
         }
+    }
 
-    </style>
-@endif
-
-@if (in_array($uiThemeService->getCurrentTheme(), ['dark', 'system'], true))
-    <style>
-        {{ $uiThemeService->getCurrentTheme() === 'system' ? '@media (prefers-color-scheme: dark) {' : '' }} :root {
-            /* Primary */
-            color-scheme: {{ $uiThemeService->getCssColorScheme() }};
-            --color-primary: {{ $uiThemeService->getCssPrimaryColor(1, true) }};
-            --color-primary-light: {{ $uiThemeService->getCssPrimaryColor(0.1, true) }};
-            --color-focus-primary: {{ $uiThemeService->getCssPrimaryColor(0.25, true) }};
-            --color-primary-hover: {{ $uiThemeService->getCssPrimaryColor(0.8, true) }};
-            --color-primary-inverse-hover: {{ $uiThemeService->getCssPrimaryColor(0.15, true) }};
-            /* Other */
-            --color-text: rgb(255, 255, 255);
-            --color-danger: rgb(226, 118, 120);
-            --color-danger-light: rgb(226, 118, 120, 0.2);
-            --color-success: rgb(75, 189, 119);
-            --color-muted: rgb(150, 150, 150);
-            --color-muted-2: rgb(130, 130, 130);
-            /* --color-muted-3: rgb(195, 207, 216); */
-            --color-border: rgba(255, 255, 255, 0.12);
-            --color-bg-base: rgb(30, 30, 30);
-            --color-bg-light: rgb(53, 53, 53);
-            --color-bg-surface: rgb(39, 39, 39);
-            --color-bg-surface-2: rgb(46, 46, 46);
-            --color-bg-surface-3: rgb(51, 51, 51);
-            --color-form-control: rgba(0, 0, 0, 0.2);
-            --color-form-control-readonly: rgb(53, 53, 53);
-            --color-form-control-focus: rgba(0, 0, 0, 0.2);
-            --color-box-shadow: rgba(0, 0, 0, 1);
-            --color-box-shadow-subdued: rgba(0, 0, 0, 0.4);
-            --color-focus-danger: rgba(226, 118, 120, 0.4);
-            --color-pre-background: rgba(255, 255, 255, 0.02);
-            --color-code-background: rgba(75, 189, 119, 0.15);
-            --color-drawer-backdrop: rgba(0, 0, 0, 0.75);
-            --color-grid-table-stripe: rgb(46, 46, 46);
-            --color-top-alert-border: rgba(28, 28, 28, 0.16);
-            --color-danger-hover: rgba(226, 118, 120, 0.8);
-            --color-success-hover: rgba(75, 189, 119, 0.8);
-        }
-
-        {{ $uiThemeService->getCurrentTheme() === 'system' ? '}' : '' }}
-
-    </style>
-@endif
+</style>

--- a/resources/views/includes/head_ui_theme_dark.blade.php
+++ b/resources/views/includes/head_ui_theme_dark.blade.php
@@ -1,0 +1,34 @@
+/* Primary */
+color-scheme: dark;
+--color-primary: {{ $uiThemeService->getCssPrimaryColor(1, true) }};
+--color-primary-light: {{ $uiThemeService->getCssPrimaryColor(0.1, true) }};
+--color-focus-primary: {{ $uiThemeService->getCssPrimaryColor(0.25, true) }};
+--color-primary-hover: {{ $uiThemeService->getCssPrimaryColor(0.8, true) }};
+--color-primary-inverse-hover: {{ $uiThemeService->getCssPrimaryColor(0.15, true) }};
+/* Other */
+--color-text: rgb(255, 255, 255);
+--color-danger: rgb(226, 118, 120);
+--color-danger-light: rgb(226, 118, 120, 0.2);
+--color-success: rgb(75, 189, 119);
+--color-muted: rgb(150, 150, 150);
+--color-muted-2: rgb(130, 130, 130);
+/* --color-muted-3: rgb(195, 207, 216); */
+--color-border: rgba(255, 255, 255, 0.12);
+--color-bg-base: rgb(30, 30, 30);
+--color-bg-light: rgb(53, 53, 53);
+--color-bg-surface: rgb(39, 39, 39);
+--color-bg-surface-2: rgb(46, 46, 46);
+--color-bg-surface-3: rgb(51, 51, 51);
+--color-form-control: rgba(0, 0, 0, 0.2);
+--color-form-control-readonly: rgb(53, 53, 53);
+--color-form-control-focus: rgba(0, 0, 0, 0.2);
+--color-box-shadow: rgba(0, 0, 0, 1);
+--color-box-shadow-subdued: rgba(0, 0, 0, 0.4);
+--color-focus-danger: rgba(226, 118, 120, 0.4);
+--color-pre-background: rgba(255, 255, 255, 0.02);
+--color-code-background: rgba(75, 189, 119, 0.15);
+--color-drawer-backdrop: rgba(0, 0, 0, 0.75);
+--color-grid-table-stripe: rgb(46, 46, 46);
+--color-top-alert-border: rgba(28, 28, 28, 0.16);
+--color-danger-hover: rgba(226, 118, 120, 0.8);
+--color-success-hover: rgba(75, 189, 119, 0.8);

--- a/resources/views/includes/head_ui_theme_light.blade.php
+++ b/resources/views/includes/head_ui_theme_light.blade.php
@@ -1,0 +1,34 @@
+/* Primary */
+color-scheme: light;
+--color-primary: {{ $uiThemeService->getCssPrimaryColor() }};
+--color-primary-light: {{ $uiThemeService->getCssPrimaryColor(0.1) }};
+--color-focus-primary: {{ $uiThemeService->getCssPrimaryColor(0.25) }};
+--color-primary-hover: {{ $uiThemeService->getCssPrimaryColor(0.8) }};
+--color-primary-inverse-hover: {{ $uiThemeService->getCssPrimaryColor(0.15) }};
+/* Other */
+--color-text: rgb(34, 41, 47);
+--color-danger: rgb(219, 60, 62);
+--color-danger-light: rgb(219, 60, 62, 0.1);
+--color-success: rgb(27, 162, 78);
+--color-muted: rgb(108, 117, 125);
+--color-muted-2: rgb(167, 182, 194);
+--color-muted-3: rgb(195, 207, 216);
+--color-border: rgb(218, 224, 230);
+--color-bg-base: rgb(243, 244, 250);
+--color-bg-light: rgb(239, 239, 239);
+--color-bg-surface: rgb(255, 255, 255);
+--color-bg-surface-2: rgb(255, 255, 255);
+--color-bg-surface-3: rgb(255, 255, 255);
+--color-form-control: rgb(250, 250, 252);
+--color-form-control-readonly: rgb(255, 255, 255);
+--color-form-control-focus: rgb(255, 255, 255);
+--color-box-shadow: rgba(34, 41, 47, 0.5);
+--color-box-shadow-subdued: rgba(34, 41, 47, 0.03);
+--color-focus-danger: rgba(219, 60, 62, 0.25);
+--color-pre-background: rgba(255, 255, 255, 0.25);
+--color-code-background: rgba(27, 162, 78, 0.1);
+--color-drawer-backdrop: rgba(34, 41, 47, 0.75);
+--color-grid-table-stripe: rgba(239, 239, 239, 0.4);
+--color-top-alert-border: rgba(255, 255, 255, 0.16);
+--color-danger-hover: rgba(219, 60, 62, 0.8);
+--color-success-hover: rgba(27, 162, 78, 0.8);


### PR DESCRIPTION
close #877

- CSS変数の出し分けは body タグに付与されている class によって行うように
- UiPrimaryColorPicker において、ダークテーマ時の色をプレビューできるように