### PR TITLE
[4.x]【お知らせ】非公開の配布資料を添付した場合でも、そのお知らせの「関連する配布資料」にその配布資料が表示されてしまう問題を修正 #956

### DIFF
--- a/app/Http/Controllers/HomeAction.php
+++ b/app/Http/Controllers/HomeAction.php
@@ -50,6 +50,11 @@ class HomeAction extends Controller
             ->with(
                 'pinned_pages',
                 Page::byCircle($circle)
+                    ->with([
+                        'documents' => function ($query) {
+                            $query->public();
+                        }
+                    ])
                     ->public()
                     ->pinned()
                     ->get()

--- a/app/Http/Controllers/HomeAction.php
+++ b/app/Http/Controllers/HomeAction.php
@@ -38,16 +38,50 @@ class HomeAction extends Controller
 
         return view('home')
             ->with('circle_custom_form', CustomForm::getFormByType('circle'))
-            ->with('my_circles', Auth::check()
-                                    ? Auth::user()->circles()->get()
-                                    : collect([]))
+            ->with(
+                'my_circles',
+                Auth::check()
+                    ? Auth::user()
+                        ->circles()
+                        ->get()
+                    : collect([])
+            )
             ->with('circle', $circle)
-            ->with('pinned_pages', Page::byCircle($circle)->public()->pinned()->get())
-            ->with('pages', Page::byCircle($circle)->take(self::TAKE_COUNT)->with(['usersWhoRead' => function ($query) {
-                $query->where('user_id', Auth::id());
-            }])->public()->pinned(false)->get())
-            ->with('documents', Document::take(self::TAKE_COUNT)->public()->get())
-            ->with('forms', Form::byCircle($circle)->take(self::TAKE_COUNT)
-                ->public()->open()->withoutCustomForms()->closeOrder()->get());
+            ->with(
+                'pinned_pages',
+                Page::byCircle($circle)
+                    ->public()
+                    ->pinned()
+                    ->get()
+            )
+            ->with(
+                'pages',
+                Page::byCircle($circle)
+                    ->take(self::TAKE_COUNT)
+                    ->with([
+                        'usersWhoRead' => function ($query) {
+                            $query->where('user_id', Auth::id());
+                        },
+                    ])
+                    ->public()
+                    ->pinned(false)
+                    ->get()
+            )
+            ->with(
+                'documents',
+                Document::take(self::TAKE_COUNT)
+                    ->public()
+                    ->get()
+            )
+            ->with(
+                'forms',
+                Form::byCircle($circle)
+                    ->take(self::TAKE_COUNT)
+                    ->public()
+                    ->open()
+                    ->withoutCustomForms()
+                    ->closeOrder()
+                    ->get()
+            );
     }
 }

--- a/app/Http/Controllers/Pages/ShowAction.php
+++ b/app/Http/Controllers/Pages/ShowAction.php
@@ -37,6 +37,10 @@ class ShowAction extends Controller
             $this->readsService->markAsRead($page, Auth::user());
         }
 
+        $page->loadMissing(['documents' => function ($query) {
+            $query->public();
+        }]);
+
         return view('pages.show')
             ->with('page', $page);
     }

--- a/app/Services/Pages/PagesService.php
+++ b/app/Services/Pages/PagesService.php
@@ -272,11 +272,14 @@ class PagesService
             ->get();
         $body = $page->body;
 
+        $page->loadMissing(['documents' => function ($query) {
+            $query->public();
+        }]);
+
         // 関連する配布資料の一覧を末尾に追加する
         if ($page->documents->count() > 0) {
             $documents_markdown_list = $page
-                ->documents()
-                ->get()
+                ->documents
                 ->map(function ($document) {
                     $escaped_name = $this->formatTextService->escapeMarkdown(
                         e($document->name)

--- a/resources/views/staff/pages/form.blade.php
+++ b/resources/views/staff/pages/form.blade.php
@@ -2,6 +2,8 @@
 
 @section('title', empty($page) ? '新規作成 — お知らせ' : "{$page->title} — お知らせ")
 
+@section('top_alert_props', 'container-fluid')
+
 @section('navbar')
     <app-nav-bar-back href="{{ route('staff.pages.index') }}">
         お知らせ管理

--- a/tests/Feature/Http/Controllers/Pages/ShowActionTest.php
+++ b/tests/Feature/Http/Controllers/Pages/ShowActionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Http\Controllers\Pages;
 
+use App\Eloquents\Document;
 use App\Eloquents\Page;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -43,5 +44,37 @@ class ShowActionTest extends TestCase
             $response->assertForbidden();
             $response->assertDontSee($page_title);
         }
+    }
+
+    /**
+     * @test
+     */
+    public function お知らせに添付されている非公開の配布資料が一覧に表示されない()
+    {
+        /** @var Page */
+        $page = factory(Page::class)->create([
+            'is_public' => true,
+        ]);
+
+        /** @var Document */
+        $public_document = factory(Document::class)->create([
+            'name' => '公開されている配布資料',
+            'is_public' => true,
+        ]);
+
+        /** @var Document */
+        $private_document = factory(Document::class)->create([
+            'name' => '非公開の配布資料',
+            'is_public' => false,
+        ]);
+
+        $page->documents()->save($public_document);
+        $page->documents()->save($private_document);
+
+        $response = $this->get(route('pages.show', ['page' => $page]));
+
+        $response->assertOk();
+        $response->assertSee('公開されている配布資料');
+        $response->assertDontSee('非公開の配布資料');
     }
 }


### PR DESCRIPTION
close #956 