### PR TITLE
【お知らせ】お知らせ一覧画面上でお知らせをピン留めできるようにする #1474

### DIFF
--- a/app/Http/Controllers/Staff/Pages/PatchPinAction.php
+++ b/app/Http/Controllers/Staff/Pages/PatchPinAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Staff\Pages;
+
+use App\Eloquents\Page;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Staff\Pages\PatchPinRequest;
+use App\Services\Pages\PagesService;
+
+class PatchPinAction extends Controller
+{
+    /**
+     * @var PagesService
+     */
+    private $pagesService;
+
+    public function __construct(PagesService $pagesService)
+    {
+        $this->pagesService = $pagesService;
+    }
+
+    public function __invoke(PatchPinRequest $request, Page $page)
+    {
+        $values = $request->validated();
+        $isPinned = (bool)$values['is_pinned'];
+
+        $this->pagesService->setPinStatusForPage($page, $isPinned);
+
+        return redirect()
+            ->route('staff.pages.index')
+            ->with('topAlert.title', $isPinned ? 'お知らせを固定表示しました' : 'お知らせの固定表示を解除しました');
+    }
+}

--- a/app/Http/Requests/Staff/Pages/PatchPinRequest.php
+++ b/app/Http/Requests/Staff/Pages/PatchPinRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Staff\Pages;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PatchPinRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'is_pinned' => ['nullable', 'boolean'],
+        ];
+    }
+
+    /**
+     * バリデーションエラーのカスタム属性の取得
+     *
+     * @return array
+     */
+    public function attributes()
+    {
+        return [
+            'is_pinned' => 'お知らせを固定表示',
+        ];
+    }
+}

--- a/app/Services/Pages/PagesService.php
+++ b/app/Services/Pages/PagesService.php
@@ -245,6 +245,15 @@ class PagesService
         });
     }
 
+    public function setPinStatusForPage(Page $page, bool $is_pinned)
+    {
+        return DB::transaction(function () use ($page, $is_pinned) {
+            $page->is_pinned = $is_pinned;
+            $page->timestamps = false;
+            return $page->save();
+        });
+    }
+
     public function removePage(Page $page)
     {
         return DB::transaction(function () use ($page) {

--- a/resources/js/v2/components/FormWithConfirm.vue
+++ b/resources/js/v2/components/FormWithConfirm.vue
@@ -1,5 +1,11 @@
 <template>
-  <form :action="action" :method="method" @submit="onSubmit">
+  <form
+    :action="action"
+    :method="method"
+    @submit="onSubmit"
+    class="form-with-confirm"
+    :class="{ 'is-inline': inline }"
+  >
     <slot />
   </form>
 </template>
@@ -11,16 +17,20 @@ export default {
   props: {
     action: {
       type: String,
-      required: true
+      required: true,
     },
     method: {
       type: String,
-      required: true
+      required: true,
     },
     confirmMessage: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
+    inline: {
+      type: Boolean,
+      default: false,
+    },
   },
   methods: {
     onSubmit(evt) {
@@ -37,7 +47,15 @@ export default {
         // }
         // /* eslint-enable */
       }
-    }
-  }
+    },
+  },
 }
 </script>
+
+<style lang="scss" scoped>
+.form-with-confirm {
+  &.is-inline {
+    display: inline;
+  }
+}
+</style>

--- a/resources/js/v2/components/FormWithConfirm.vue
+++ b/resources/js/v2/components/FormWithConfirm.vue
@@ -17,20 +17,20 @@ export default {
   props: {
     action: {
       type: String,
-      required: true,
+      required: true
     },
     method: {
       type: String,
-      required: true,
+      required: true
     },
     confirmMessage: {
       type: String,
-      required: true,
+      required: true
     },
     inline: {
       type: Boolean,
-      default: false,
-    },
+      default: false
+    }
   },
   methods: {
     onSubmit(evt) {
@@ -47,8 +47,8 @@ export default {
         // }
         // /* eslint-enable */
       }
-    },
-  },
+    }
+  }
 }
 </script>
 

--- a/resources/js/v2/components/IconButton.vue
+++ b/resources/js/v2/components/IconButton.vue
@@ -8,6 +8,7 @@
     :rel="newtab ? 'noopener noreferrer' : undefined"
     v-bind="disabledProps"
     class="icon-button"
+    :class="{ 'is-active': active }"
     @click="handleClick"
   >
     <slot />
@@ -19,33 +20,37 @@ export default {
   props: {
     href: {
       type: String,
-      default: undefined
+      default: undefined,
     },
     submit: {
       type: Boolean,
-      default: false
+      default: false,
     },
     button: {
       type: Boolean,
-      default: true
+      default: true,
     },
     title: {
       type: String,
-      required: true
+      required: true,
     },
     newtab: {
       type: Boolean,
-      default: false
+      default: false,
     },
     disabled: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
+    active: {
+      type: Boolean,
+      default: false,
+    },
   },
   methods: {
     handleClick(e) {
       this.$emit('click', e)
-    }
+    },
   },
   computed: {
     componentIs() {
@@ -65,14 +70,14 @@ export default {
 
       if (this.href) {
         return {
-          class: 'is-disabled'
+          class: 'is-disabled',
         }
       }
       return {
-        disabled: true
+        disabled: true,
       }
-    }
-  }
+    },
+  },
 }
 </script>
 
@@ -105,6 +110,10 @@ export default {
     cursor: not-allowed;
     opacity: 0.5;
     pointer-events: none;
+  }
+  &.is-active {
+    background-color: $color-primary-light;
+    color: $color-primary;
   }
 }
 </style>

--- a/resources/js/v2/components/IconButton.vue
+++ b/resources/js/v2/components/IconButton.vue
@@ -20,37 +20,37 @@ export default {
   props: {
     href: {
       type: String,
-      default: undefined,
+      default: undefined
     },
     submit: {
       type: Boolean,
-      default: false,
+      default: false
     },
     button: {
       type: Boolean,
-      default: true,
+      default: true
     },
     title: {
       type: String,
-      required: true,
+      required: true
     },
     newtab: {
       type: Boolean,
-      default: false,
+      default: false
     },
     disabled: {
       type: Boolean,
-      default: false,
+      default: false
     },
     active: {
       type: Boolean,
-      default: false,
-    },
+      default: false
+    }
   },
   methods: {
     handleClick(e) {
       this.$emit('click', e)
-    },
+    }
   },
   computed: {
     componentIs() {
@@ -70,14 +70,14 @@ export default {
 
       if (this.href) {
         return {
-          class: 'is-disabled',
+          class: 'is-disabled'
         }
       }
       return {
-        disabled: true,
+        disabled: true
       }
-    },
-  },
+    }
+  }
 }
 </script>
 

--- a/resources/views/staff/pages/index.blade.php
+++ b/resources/views/staff/pages/index.blade.php
@@ -6,17 +6,17 @@
 
 @section('content')
     <staff-grid api-url="{{ route('staff.pages.api') }}" v-bind:key-translations="{
-                                                    id: 'お知らせID',
-                                                    title: 'タイトル',
-                                                    viewableTags: '閲覧可能なタグ',
-                                                    documents: '関連する配布資料',
-                                                    body: '本文',
-                                                    is_pinned: '固定',
-                                                    is_public: '公開',
-                                                    created_at: '作成日時',
-                                                    updated_at: '更新日時',
-                                                    notes: 'スタッフ用メモ',
-                                                }">
+                            id: 'お知らせID',
+                            title: 'タイトル',
+                            viewableTags: '閲覧可能なタグ',
+                            documents: '関連する配布資料',
+                            body: '本文',
+                            is_pinned: '固定',
+                            is_public: '公開',
+                            created_at: '作成日時',
+                            updated_at: '更新日時',
+                            notes: 'スタッフ用メモ',
+                        }">
         <template v-slot:toolbar>
             <a class="btn is-primary" href="{{ route('staff.pages.create') }}">
                 <i class="fas fa-plus fa-fw"></i>

--- a/resources/views/staff/pages/index.blade.php
+++ b/resources/views/staff/pages/index.blade.php
@@ -6,17 +6,17 @@
 
 @section('content')
     <staff-grid api-url="{{ route('staff.pages.api') }}" v-bind:key-translations="{
-                            id: 'お知らせID',
-                            title: 'タイトル',
-                            viewableTags: '閲覧可能なタグ',
-                            documents: '関連する配布資料',
-                            body: '本文',
-                            is_pinned: '固定',
-                            is_public: '公開',
-                            created_at: '作成日時',
-                            updated_at: '更新日時',
-                            notes: 'スタッフ用メモ',
-                        }">
+                                                    id: 'お知らせID',
+                                                    title: 'タイトル',
+                                                    viewableTags: '閲覧可能なタグ',
+                                                    documents: '関連する配布資料',
+                                                    body: '本文',
+                                                    is_pinned: '固定',
+                                                    is_public: '公開',
+                                                    created_at: '作成日時',
+                                                    updated_at: '更新日時',
+                                                    notes: 'スタッフ用メモ',
+                                                }">
         <template v-slot:toolbar>
             <a class="btn is-primary" href="{{ route('staff.pages.create') }}">
                 <i class="fas fa-plus fa-fw"></i>
@@ -33,16 +33,16 @@
             </a>
         </template>
         <template v-slot:activities="{ row }">
+            <icon-button
+                v-bind:href="`{{ route('staff.pages.edit', ['page' => '%%PAGE%%']) }}`.replace('%%PAGE%%', row['id'])"
+                title="編集">
+                <i class="fas fa-pencil-alt fa-fw"></i>
+            </icon-button>
             <form-with-confirm
                 v-bind:action="`{{ route('staff.pages.destroy', ['page' => '%%PAGE%%']) }}`.replace('%%PAGE%%', row['id'])"
-                method="post" v-bind:confirm-message="`お知らせ「${row['title']}」を削除しますか？`">
+                method="post" v-bind:confirm-message="`お知らせ「${row['title']}」を削除しますか？`" inline>
                 @method('delete')
                 @csrf
-                <icon-button
-                    v-bind:href="`{{ route('staff.pages.edit', ['page' => '%%PAGE%%']) }}`.replace('%%PAGE%%', row['id'])"
-                    title="編集">
-                    <i class="fas fa-pencil-alt fa-fw"></i>
-                </icon-button>
                 <icon-button submit title="削除">
                     <i class="fas fa-trash fa-fw"></i>
                 </icon-button>

--- a/resources/views/staff/pages/index.blade.php
+++ b/resources/views/staff/pages/index.blade.php
@@ -38,6 +38,18 @@
                 title="編集">
                 <i class="fas fa-pencil-alt fa-fw"></i>
             </icon-button>
+            <form style="display: inline"
+                v-bind:action="`{{ route('staff.pages.pin', ['page' => '%%PAGE%%']) }}`.replace('%%PAGE%%', row['id'])"
+                method="post">
+                @method('patch')
+                @csrf
+                {{-- 現在の is_pinned と反転させた値をフォームで送信する --}}
+                <input type="hidden" name="is_pinned" v-bind:value="row['is_pinned'] ? 0 : 1">
+                <icon-button v-bind:active="row['is_pinned']" submit
+                    v-bind:title="row['is_pinned'] ? '固定表示を解除する' : '固定表示する'">
+                    <i class="fas fa-thumbtack fa-fw"></i>
+                </icon-button>
+            </form>
             <form-with-confirm
                 v-bind:action="`{{ route('staff.pages.destroy', ['page' => '%%PAGE%%']) }}`.replace('%%PAGE%%', row['id'])"
                 method="post" v-bind:confirm-message="`お知らせ「${row['title']}」を削除しますか？`" inline>

--- a/routes/staff.php
+++ b/routes/staff.php
@@ -55,6 +55,7 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
                 Route::get('/{page}/edit', 'Staff\Pages\EditAction')->name('edit')->middleware(['can:staff.pages.edit']);
                 Route::patch('/{page}', 'Staff\Pages\UpdateAction')->name('update')->middleware(['can:staff.pages.edit']);
                 Route::delete('/{page}', 'Staff\Pages\DestroyAction')->name('destroy')->middleware(['can:staff.pages.delete']);
+                Route::patch('/{page}/pin', 'Staff\Pages\PatchPinAction')->name('pin')->middleware(['can:staff.pages.edit']);
                 Route::get('/export', 'Staff\Pages\ExportAction')->name('export')->middleware(['can:staff.pages.export']);
             });
 
@@ -113,8 +114,7 @@ Route::middleware(['auth', 'verified', 'can:staff', 'staffAuthed'])
                 Route::get('/preview', 'Staff\Forms\PreviewAction')->name('preview')->middleware(['can:staff.forms.read']);
 
                 // フォームの複製
-                Route::post('/copy', 'Staff\Forms\CopyAction')->name('copy')->middleware(['can:staff.forms.duplicate']);
-                ;
+                Route::post('/copy', 'Staff\Forms\CopyAction')->name('copy')->middleware(['can:staff.forms.duplicate']);;
             });
 
         Route::prefix('/users')

--- a/tests/Feature/Services/Pages/PagesServiceTest.php
+++ b/tests/Feature/Services/Pages/PagesServiceTest.php
@@ -69,6 +69,58 @@ class PagesServiceTest extends TestCase
     /**
      * @test
      */
+    public function setPinStatusForPage_お知らせを固定表示できる()
+    {
+        $page = $this->pagesService->createPage(
+            $this->content['title'],
+            $this->content['body'],
+            $this->staff,
+            '',
+            [],
+            [],
+            $this->content['is_public'],
+            0,
+        );
+
+        $this->pagesService->setPinStatusForPage($page, true);
+
+        $content_on_db = $this->content;
+        $content_on_db['body'] = $this->content['body'];
+        $content_on_db['is_pinned'] = true;
+
+        $this->assertSame(1, Page::count());
+        $this->assertDatabaseHas('pages', $content_on_db);
+    }
+
+    /**
+     * @test
+     */
+    public function setPinStatusForPage_お知らせを固定解除できる()
+    {
+        $page = $this->pagesService->createPage(
+            $this->content['title'],
+            $this->content['body'],
+            $this->staff,
+            '',
+            [],
+            [],
+            $this->content['is_public'],
+            1,
+        );
+
+        $this->pagesService->setPinStatusForPage($page, false);
+
+        $content_on_db = $this->content;
+        $content_on_db['body'] = $this->content['body'];
+        $content_on_db['is_pinned'] = false;
+
+        $this->assertSame(1, Page::count());
+        $this->assertDatabaseHas('pages', $content_on_db);
+    }
+
+    /**
+     * @test
+     */
     public function updatePage()
     {
         $this->assertSame(0, Page::count());


### PR DESCRIPTION
close #1474

スタッフモードの「お知らせ管理」画面で、お知らせをワンクリックで固定表示・固定解除できるようにしました。

<img width="265" alt="image" src="https://user-images.githubusercontent.com/6687653/230087409-aa017432-38fd-42a7-91da-96d5a31d23b8.png">
