### PR TITLE
テストメール送信処理の例外はすべてキャッチするように修正

### DIFF
--- a/app/Http/Controllers/Install/Mail/UpdateAction.php
+++ b/app/Http/Controllers/Install/Mail/UpdateAction.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers\Install\Mail;
 
-use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Exception;
 use Symfony\Component\Mailer\Transport;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Install\MailRequest;
@@ -28,7 +28,7 @@ class UpdateAction extends Controller
 
             return redirect()
                 ->route('install.admin.create');
-        } catch (TransportExceptionInterface $e) {
+        } catch (Exception $e) {
             return redirect()
                 ->back()
                 ->withInput()

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -7,6 +7,7 @@ use Faker\Generator as Faker;
 
 $factory->define(Tag::class, function (Faker $faker) {
     return [
-        'name' => $faker->name,
+        // 同じnameが2つ以上生成されないよう、乱数を追加する
+        'name' => $faker->name . strval(mt_rand(0, 10000)),
     ];
 });


### PR DESCRIPTION
close #1480

テストメール送信時にExceptionが発生した場合、発生したExceptionの種類に関わらず、以下のようにエラーメッセージを表示するように変更。

![CleanShot 2023-04-16 at 18 10 04](https://user-images.githubusercontent.com/6687653/232288776-e3c4e6c3-8a20-4435-9620-293720b8e7cb.png)
