### PR TITLE
【Staff/申請管理】申請への回答一覧の内容もフィルター可能にする #1501

### DIFF
--- a/.github/workflows/testcases.yml
+++ b/.github/workflows/testcases.yml
@@ -98,8 +98,9 @@ jobs:
     - uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
+        tools: cs2pr
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/checkout@v2
     - name: Use Node.js (Yarnをインストールするため)
       uses: actions/setup-node@v2
@@ -129,7 +130,7 @@ jobs:
     - name: Directory Permissions
       run: chmod -R 777 storage bootstrap/cache
     - name: phpcs
-      run: composer phpcs
+      run: composer phpcs-github-actions
     - name: マイグレーション
       run: php artisan migrate --env=testing --force
     - name: PHPUnitでテスト実行

--- a/app/GridMakers/AnswersGridMaker.php
+++ b/app/GridMakers/AnswersGridMaker.php
@@ -71,6 +71,7 @@ class AnswersGridMaker implements GridMakable
                     case 'heading':
                         return null;
                     case 'number':
+                        // phpcs:ignore
                         return "MAX(CAST(CASE WHEN question_id = {$idInt} THEN answer ELSE NULL END AS DECIMAL(10, 0))) AS '{$columnAlias}'";
                     case 'text':
                     case 'textarea':
@@ -80,6 +81,7 @@ class AnswersGridMaker implements GridMakable
                         return "MAX(CASE WHEN question_id = {$idInt} THEN answer ELSE NULL END) AS '{$columnAlias}'";
                     case 'checkbox':
                         $separator = self::CHECKBOX_GROUP_CONCAT_SEPARATOR;
+                        // phpcs:ignore
                         return "GROUP_CONCAT(CASE WHEN question_id = {$idInt} THEN answer ELSE NULL END SEPARATOR '{$separator}') AS '{$columnAlias}'";
                 }
             })
@@ -222,7 +224,9 @@ class AnswersGridMaker implements GridMakable
                     ])
                 ] : [];
             } elseif ($question->type === 'checkbox') {
-                $item[$formKey] = isset($answerValue) ? explode(self::CHECKBOX_GROUP_CONCAT_SEPARATOR, $answerValue) : [];
+                $item[$formKey] = isset($answerValue)
+                    ? explode(self::CHECKBOX_GROUP_CONCAT_SEPARATOR, $answerValue)
+                    : [];
             } else {
                 $item[$formKey] = [$answerValue];
             }

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
         "phpcs": [
             "phpcs --standard=phpcs.xml ./"
         ],
+        "phpcs-github-actions": [
+            "phpcs -q --report=checkstyle ./ | cs2pr"
+        ],
         "phpcbf": [
             "phpcbf --standard=phpcs.xml ./"
         ],


### PR DESCRIPTION
close #1501

* スタッフモード > 申請管理の回答一覧ページにおいて、回答の絞り込み・並べ替えをできるようにしました。

<img src="https://user-images.githubusercontent.com/6687653/233784956-ac27689d-b826-42dc-a2ed-443bac25ed12.png" width="300" />